### PR TITLE
add workflow_service method to all robots

### DIFF
--- a/robots/robots.rb
+++ b/robots/robots.rb
@@ -1,4 +1,5 @@
 # Put each of your robots here and they will be included via config/boot'
+require 'was/robots/base'
 
 require 'wasCrawlDissemination/cdx_generator'
 require 'wasCrawlDissemination/cdx_merge_sort_publish'

--- a/robots/was/robots/base.rb
+++ b/robots/was/robots/base.rb
@@ -1,0 +1,9 @@
+module Was
+  module Robots
+    module Base
+      def workflow_service
+        Dor::Config.workflow.client
+      end
+    end
+  end
+end

--- a/robots/wasCrawlDissemination/cdx_generator.rb
+++ b/robots/wasCrawlDissemination/cdx_generator.rb
@@ -4,6 +4,7 @@ module Robots
     module WasCrawlDissemination
       class CdxGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlDisseminationWF', 'cdx-generator')

--- a/robots/wasCrawlDissemination/cdx_merge_sort_publish.rb
+++ b/robots/wasCrawlDissemination/cdx_merge_sort_publish.rb
@@ -4,6 +4,7 @@ module Robots
     module WasCrawlDissemination
       class CdxMergeSortPublish
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlDisseminationWF', 'cdx-merge-sort-publish')

--- a/robots/wasCrawlDissemination/path_indexer.rb
+++ b/robots/wasCrawlDissemination/path_indexer.rb
@@ -4,6 +4,7 @@ module Robots
     module WasCrawlDissemination
       class PathIndexer
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlDisseminationWF', 'path-indexer')

--- a/robots/wasCrawlPreassembly/build_was_crawl_druid_tree.rb
+++ b/robots/wasCrawlPreassembly/build_was_crawl_druid_tree.rb
@@ -5,6 +5,7 @@ module Robots
     module WasCrawlPreassembly
       class BuildWasCrawlDruidTree
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlPreassemblyWF', 'build-was-crawl-druid-tree')

--- a/robots/wasCrawlPreassembly/content_metadata_generator.rb
+++ b/robots/wasCrawlPreassembly/content_metadata_generator.rb
@@ -5,6 +5,7 @@ module Robots
     module WasCrawlPreassembly
       class ContentMetadataGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlPreassemblyWF', 'content-metadata-generator')

--- a/robots/wasCrawlPreassembly/desc_metadata_generator.rb
+++ b/robots/wasCrawlPreassembly/desc_metadata_generator.rb
@@ -3,6 +3,7 @@ module Robots
     module WasCrawlPreassembly
       class DescMetadataGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlPreassemblyWF', 'desc-metadata-generator')

--- a/robots/wasCrawlPreassembly/end_was_crawl_preassembly.rb
+++ b/robots/wasCrawlPreassembly/end_was_crawl_preassembly.rb
@@ -3,6 +3,7 @@ module Robots
     module WasCrawlPreassembly
       class EndWasCrawlPreassembly
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlPreassemblyWF', 'end-was-crawl-preassembly')
@@ -11,7 +12,7 @@ module Robots
         def perform(druid)
           opts = { :create_ds => true }
           opts[:lane_id] = Dor::Config.was_crawl.dedicated_lane.nil? ? 'default' : Dor::Config.was_crawl.dedicated_lane
-          Dor::WorkflowService.create_workflow('dor', druid, 'accessionWF', Dor::WorkflowObject.initial_workflow('accessionWF'), opts)
+          workflow_service.create_workflow('dor', druid, 'accessionWF', Dor::WorkflowObject.initial_workflow('accessionWF'), opts)
         end
       end
     end

--- a/robots/wasCrawlPreassembly/metadata_extractor.rb
+++ b/robots/wasCrawlPreassembly/metadata_extractor.rb
@@ -3,6 +3,7 @@ module Robots
     module WasCrawlPreassembly
       class MetadataExtractor
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlPreassemblyWF', 'metadata-extractor')

--- a/robots/wasCrawlPreassembly/technical_metadata_generator.rb
+++ b/robots/wasCrawlPreassembly/technical_metadata_generator.rb
@@ -3,6 +3,7 @@ module Robots
     module WasCrawlPreassembly
       class TechnicalMetadataGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasCrawlPreassemblyWF', 'technical-metadata-generator')

--- a/robots/wasDissemination/start_special_dissemination.rb
+++ b/robots/wasDissemination/start_special_dissemination.rb
@@ -3,6 +3,7 @@ module Robots
     module WasDissemination
       class StartSpecialDissemination
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasDisseminationWF', 'start-special-dissemination')

--- a/robots/wasSeedDissemination/update_thumbnail_generator.rb
+++ b/robots/wasSeedDissemination/update_thumbnail_generator.rb
@@ -5,6 +5,7 @@ module Robots
     module WasSeedDissemination
       class UpdateThumbnailGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasSeedDisseminationWF', 'update-thumbnail-generator')

--- a/robots/wasSeedPreassembly/build_was_seed_druid_tree.rb
+++ b/robots/wasSeedPreassembly/build_was_seed_druid_tree.rb
@@ -5,6 +5,7 @@ module Robots
     module WasSeedPreassembly
       class BuildWasSeedDruidTree
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasSeedPreassemblyWF', 'build-was-seed-druid-tree')

--- a/robots/wasSeedPreassembly/content_metadata_generator.rb
+++ b/robots/wasSeedPreassembly/content_metadata_generator.rb
@@ -3,6 +3,7 @@ module Robots
     module WasSeedPreassembly
       class ContentMetadataGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasSeedPreassemblyWF', 'content-metadata-generator')

--- a/robots/wasSeedPreassembly/desc_metadata_generator.rb
+++ b/robots/wasSeedPreassembly/desc_metadata_generator.rb
@@ -3,6 +3,7 @@ module Robots
     module WasSeedPreassembly
       class DescMetadataGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasSeedPreassemblyWF', 'desc-metadata-generator')

--- a/robots/wasSeedPreassembly/end_was_seed_preassembly.rb
+++ b/robots/wasSeedPreassembly/end_was_seed_preassembly.rb
@@ -3,6 +3,7 @@ module Robots
     module WasSeedPreassembly
       class EndWasSeedPreassembly
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasSeedPreassemblyWF', 'end-was-seed-preassembly')
@@ -10,8 +11,8 @@ module Robots
 
         def perform(druid)
           druid_obj = Dor::Item.find(druid)
-          start_completed = Dor::WorkflowService.get_workflow_status('dor', druid, 'accessionWF', 'start-accession')
-          end_completed = Dor::WorkflowService.get_workflow_status('dor', druid, 'accessionWF', 'end-accession')
+          start_completed = workflow_service.get_workflow_status('dor', druid, 'accessionWF', 'start-accession')
+          end_completed = workflow_service.get_workflow_status('dor', druid, 'accessionWF', 'end-accession')
 
           if start_completed.nil? && end_completed.nil?
             # This object isn't accessioned yet.

--- a/robots/wasSeedPreassembly/thumbnail_generator.rb
+++ b/robots/wasSeedPreassembly/thumbnail_generator.rb
@@ -3,6 +3,7 @@ module Robots
     module WasSeedPreassembly
       class ThumbnailGenerator
         include LyberCore::Robot
+        include Was::Robots::Base
 
         def initialize
           super('dor', 'wasSeedPreassemblyWF', 'thumbnail-generator')


### PR DESCRIPTION
From @drh-stanford  on orig PR (#2)

This PR includes the default workflow_service method for all robots. At least, one approach to do so.

Note that a couple robots call the workflow service directly, so those need to be changed to use the new method.

See #1

Somewhat modeled after common-accessioning -- see https://github.com/sul-dlss/common-accessioning/blob/master/robots/accession/base.rb
