### PR TITLE
wait for dor-services-app to return druid to was-registrar for source XML file for seed

### DIFF
--- a/robots/wasSeedPreassembly/build_was_seed_druid_tree.rb
+++ b/robots/wasSeedPreassembly/build_was_seed_druid_tree.rb
@@ -19,6 +19,15 @@ module Robots
           druid_tree_directory = DruidTools::Druid.new(druid, workspace_path)
           source_xml_file = staging_path + "#{druid}.xml"
 
+          # Wait for dor-services-app to finish registering object, and firing off workflow
+          # whereas was-registrar needs to wait for dor-services-app to finish to get the druid
+          # for the source XML file. So, we wait here for up to 5 mins for this file to appear.
+          (1..10).each do |i|
+            break if File.file?(source_xml_file)
+            LyberCore::Log.info "Waiting for source XML file: Try #{i}: #{source_xml_file}..."
+            sleep(30)
+          end
+
           fail "There is no source xml file at #{source_xml_file} for druid #{druid}." unless File.file?(source_xml_file)
 
           FileUtils.cp source_xml_file, "#{druid_tree_directory.content_dir}/source.xml"


### PR DESCRIPTION
This PR loops for 5 mins until the seed's source xml file shows up (after dor-services-app returns from register call in was-registrar).