### PR TITLE
add bundle_without

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -6,3 +6,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :deploy_environment, 'development'
 set :whenever_environment, fetch(:deploy_environment)
 set :default_env, { robot_environment: fetch(:deploy_environment) }
+set :bundle_without, %w{deployment test}.join(' ')

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,3 +5,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :deploy_environment, 'production'
 set :whenever_environment, fetch(:deploy_environment)
 set :default_env, { robot_environment: fetch(:deploy_environment) }
+set :bundle_without, %w{deployment development test}.join(' ')

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -5,3 +5,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :deploy_environment, 'test'
 set :whenever_environment, fetch(:deploy_environment)
 set :default_env, { robot_environment: fetch(:deploy_environment) }
+set :bundle_without, %w{deployment test}.join(' ')


### PR DESCRIPTION
This PR excludes the `deployment`, `test`, and optionally  `development` gemsets on deploy. This PR is connected to #8