### PR TITLE
switch deploy to use was-robots1-* VMs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,8 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.2
   Exclude:
-    - 'config/environments/test.rb'
+    - 'config/deploy/*.rb'
+    - 'config/environments/*.rb'
     - 'vendor/**/*'
 
 # because it's silly to care

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,7 +55,7 @@ Style/AlignParameters:
 Style/BracesAroundHashParameters:
   Exclude:
     - 'config/deploy/dev.rb'
-    - 'config/deploy/production.rb'
+    - 'config/deploy/prod.rb'
     - 'config/deploy/stage.rb'
     - 'spec/wasCrawlPreassembly/robots/end_was_crawl_preassembly_spec.rb'
 
@@ -200,7 +200,7 @@ Style/NestedParenthesizedCalls:
 Style/PercentLiteralDelimiters:
   Exclude:
     - 'config/deploy/dev.rb'
-    - 'config/deploy/production.rb'
+    - 'config/deploy/prod.rb'
     - 'config/deploy/stage.rb'
 
 # Offense count: 2

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,5 +1,4 @@
-server 'sul-robots1-dev.stanford.edu', user: 'lyberadmin', roles: %w{web app db}
-#server 'sul-robots2-dev.stanford.edu', user: 'lyberadmin', roles: %w{web app db}
+server 'was-robots1-dev.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,4 @@
-server 'sul-robots3-prod.stanford.edu', user: 'lyberadmin', roles: %w{web app db}
+server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,4 +1,4 @@
-server 'sul-robots5-test.stanford.edu', user: 'lyberadmin', roles: %w{web app db}
+server 'was-robots1-stage.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
This PR updates the cap deploy scripties to use the new was-robots1-* VMs.