### PR TITLE
add shared_configs:update to cap restart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ group :development, :test do
 end
 
 group :deployment do
-  gem 'capistrano'
   gem 'capistrano-bundler'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    airbrussh (1.0.2)
+    airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     assembly-image (1.6.8)
       activesupport (> 3)
@@ -47,23 +47,24 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.2)
-    capistrano (3.5.0)
+    capistrano (3.7.0)
       airbrussh (>= 1.0.0)
       capistrano-harrow
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundle_audit (0.0.5)
-      bundler-audit
+    capistrano-bundle_audit (0.2.1)
+      bundler-audit (~> 0.5)
       capistrano (~> 3.0)
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-harrow (0.5.2)
+    capistrano-harrow (0.5.3)
     capistrano-one_time_key (0.0.1)
       capistrano (~> 3.0)
     capistrano-releaseboard (0.0.1)
       faraday
+    capistrano-shared_configs (0.1.1)
     chronic (0.10.2)
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -79,11 +80,12 @@ GEM
     deprecation (1.0.0)
       activesupport
     diff-lcs (1.2.5)
-    dlss-capistrano (3.2.0)
+    dlss-capistrano (3.4.0)
       capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.0.3)
+      capistrano-bundle_audit (>= 0.1.0)
       capistrano-one_time_key
       capistrano-releaseboard
+      capistrano-shared_configs
     docile (1.1.5)
     docopt (0.5.0)
     domain_name (0.5.20160615)
@@ -293,7 +295,7 @@ GEM
       nokogiri
       stomp
       xml-simple
-    sshkit (1.11.1)
+    sshkit (1.11.4)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stanford-mods (1.5.3)
@@ -304,7 +306,7 @@ GEM
     systemu (2.6.5)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
     tins (1.6.0)
@@ -330,7 +332,6 @@ PLATFORMS
 DEPENDENCIES
   assembly-image
   awesome_print
-  capistrano
   capistrano-bundler
   codeclimate-test-reporter
   coveralls
@@ -353,4 +354,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,14 +58,19 @@ namespace :deploy do
     on roles(:app), in: :sequence, wait: 10 do
       within release_path do
         test :bundle, :exec, :controller, :stop
-        sleep 15
+        sleep 15 # wait for clean stop
         test :bundle, :exec, :controller, :quit
         execute :bundle, :exec, :controller, :boot
       end
     end
   end
 
+  # update shared_configs before restarting app
+  before :restart, 'shared_configs:update'
+
+  # Download and extract JARs before restarting
+  before :restart, :download_metadata_extractor_tar
+  before :restart, :download_openwayback_tar
+
   after :publishing, :restart
-  after :restart, :download_metadata_extractor_tar
-  after :restart, :download_openwayback_tar
 end


### PR DESCRIPTION
This PR adds `shared_configs:update` as a precursor to `deploy:restart`. Also, fixes the JAR file downloads to happen before, not after, a restart.

The PR updates dlss-capistrano to 3.4 in order to get the shared_configs stuff.

This PR fixes #26 .