### PR TITLE
only run robots:verify cronjob in production

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,4 @@
-server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db}
+server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db monitor}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-every 5.minutes do
+every 5.minutes, roles: [:monitor] do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }
   set :environment_variable, 'ROBOT_ENVIRONMENT'


### PR DESCRIPTION
This PR is connected to #19. We only need the monitoring in production.