### PR TITLE
add index rollup tasks and schedule for log-level indexing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ cache: bundler
 rvm:
   - 2.2.4
 
+env:
+  - ROBOT_ENVIRONMENT=test
+
 before_script:
   - cp config/environments/example.rb config/environments/test.rb

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'robot-controller', '~> 2.1', '>= 2.1.1' # requires Resque
 # need master rather than released version (as of 1/18/17)
 gem 'bluepill', git: 'https://github.com/bluepill-rb/bluepill.git'
 
+gem 'lockfile'       # file locks needed for mutual exclusion during rollup and index addition processes
 gem 'phantomjs'      # was-seed-preassembly thumbnail creation
 gem 'mini_exiftool'  # was-seed-preassembly thumbnail creation
 gem 'mini_magick'    # was-seed-preassembly thumbnail creation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
       rdf-xsd (~> 1.1, >= 1.1.5)
       sparql (~> 1.99)
       sparql-client (~> 1.99)
+    lockfile (2.1.3)
     lyber-core (4.1.1)
       activesupport
       dor-workflow-service (>= 1.7, < 3)
@@ -436,6 +437,7 @@ DEPENDENCIES
   druid-tools
   equivalent-xml
   honeybadger (~> 2.0)
+  lockfile
   lyber-core (~> 4.1, >= 4.1.1)
   mini_exiftool
   mini_magick

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,5 +1,4 @@
-# TODO: add 'rollup' to roles when ready for multi-level CDX indexing jobs
-server 'was-robots1-dev.stanford.edu', user: 'was', roles: %w{web app db}
+server 'was-robots1-dev.stanford.edu', user: 'was', roles: %w{web app db rollup}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,3 +1,4 @@
+# TODO: add 'rollup' to roles when ready for multi-level CDX indexing jobs
 server 'was-robots1-dev.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,4 @@
-# TODO: add 'rollup' to roles when ready for multi-level CDX indexing jobs
-server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db monitor}
+server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db monitor rollup}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,3 +1,4 @@
+# TODO: add 'rollup' to roles when ready for multi-level CDX indexing jobs
 server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db monitor}
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,5 +1,4 @@
-# TODO: add 'rollup' to roles when ready for multi-level CDX indexing jobs
-server 'was-robots1-stage.stanford.edu', user: 'was', roles: %w{web app db}
+server 'was-robots1-stage.stanford.edu', user: 'was', roles: %w{web app db rollup}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,3 +1,4 @@
+# TODO: add 'rollup' to roles when ready for multi-level CDX indexing jobs
 server 'was-robots1-stage.stanford.edu', user: 'was', roles: %w{web app db}
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/environments/example.rb
+++ b/config/environments/example.rb
@@ -45,7 +45,7 @@ Dor::Config.configure do
     java_heap_size  '-Xmx1024m'
     cdx_working_directory "/web-archiving-stacks/data/indices/cdx_working/"
     cdx_backup_directory  "/web-archiving-stacks/data/indices/cdx_backup/"
-    main_cdx_file "/web-archiving-stacks/data/indices/cdx/index.cdx"
+    main_cdx_file "/web-archiving-stacks/data/indices/cdx/level0.cdx"
 
     path_working_directory "/web-archiving-stacks/data/indices/path_working/"
     main_path_index_file "/web-archiving-stacks/data/indices/path/path-index.txt"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,16 @@
+set :output, 'log/cdx_index_rollup.log'
+every 1.day, roles: [:rollup] do
+  rake 'cdx:index:rollup:level1'
+end
+
+every 1.month, roles: [:rollup] do
+  rake 'cdx:index:rollup:level2'
+end
+
+every 12.months, roles: [:rollup] do
+  rake 'cdx:index:rollup:level3'
+end
+
 every 5.minutes, roles: [:monitor] do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -32,6 +32,19 @@ namespace :cdx do
         srcfn.rename(dstfn)
         Rake::Task['cdx:index:admin:setup'].execute
       end
+
+      namespace :lockfile do
+        desc "Show lockfile"
+        task :show do
+          system("ls -l #{INDEX_DIR.join('working.lock')}")
+        end
+
+        desc "Remove a stale lockfile"
+        task :remove do
+          lockfile = INDEX_DIR.join('working.lock')
+          lockfile.delete if lockfile.exist?
+        end
+      end
     end
 
     namespace :rollup do

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -1,0 +1,96 @@
+require 'lockfile'
+
+require File.dirname(__FILE__) + '../../../config/boot' # for Dor::Config settings
+
+# Location of the CDX index files
+INDEX_DIR = Pathname.new(File.dirname(Dor::Config.was_crawl_dissemination.main_cdx_file)).freeze
+
+namespace :cdx do
+  namespace :index do
+    desc "Show all CDX indexes"
+    task :show do
+      system("ls -l #{INDEX_DIR}/level?.cdx")
+    end
+
+    namespace :admin do
+      desc "Setup all CDX indexes (i.e., creates empty file if not present)"
+      task :setup do
+        (0..3).each do |i|
+          fn = "#{INDEX_DIR}/level#{i}.cdx"
+          FileUtils.touch(fn) unless File.exist?(fn)
+        end
+        Rake::Task['cdx:index:show'].execute
+      end
+
+      desc "Migrate old index file into multi-level index files"
+      task :migrate do
+        srcfn = INDEX_DIR.join('index.cdx')
+        dstfn = INDEX_DIR.join('level3.cdx')
+        raise "Old index is not present: #{srcfn}" unless srcfn.exist?
+        dstfn.delete if dstfn.zero?
+        raise "Level3 index already exists: #{dstfn}" if dstfn.exist?
+        srcfn.rename(dstfn)
+        Rake::Task['cdx:index:admin:setup'].execute
+      end
+    end
+
+    namespace :rollup do
+      def merge(n, src, dst)
+        # load required environment variables from configuration file
+        unless Dor::Config.was_crawl_dissemination.sort_env_vars.nil?
+          Dor::Config.was_crawl_dissemination.sort_env_vars.split.each do |statement|
+            ENV[statement.split(/=/).first] = statement.split(/=/).last
+          end
+        end
+
+        # we need to merge the 2 *already sorted* files into the new file, and
+        # then zero out the current level of index
+        oflags = '--buffer-size=128M' # merge optimization flags
+        cmd = "sort --merge --unique #{oflags} --output=#{dst}.new #{src} #{dst}"
+        puts "Merging via #{cmd}"
+        if system(cmd)
+          FileUtils.mv("#{dst}.new", dst.to_s)
+          FileUtils.rm(src.to_s)
+          FileUtils.touch(src.to_s)
+          puts "Rolled up level#{n} into level#{n + 1} CDX index"
+        else
+          puts "Failed to roll up level#{n} into level#{n + 1} CDX index. Cleaning up..."
+          FileUtils.rm("#{dst}.new")
+        end
+      end
+
+      def rollup(n) # n is the log level from which to rollup
+        src = INDEX_DIR.join("level#{n}.cdx")
+        dst = INDEX_DIR.join("level#{n + 1}.cdx")
+
+        # ensure only 1 rollup process at a time, and robots should use the
+        # working.lock file to also to block while rollup work is being done
+        Lockfile.new(INDEX_DIR.join('working.lock').to_s) do
+          raise "Missing #{src} file" unless src.exist?
+          raise "Missing #{dst} file" unless dst.exist?
+
+          if src.zero?
+            puts "Nothing to do. No data in #{src}"
+          else
+            merge(n, src, dst)
+          end
+        end
+      end
+
+      desc "Rollup Level0 (today) into Level1 (daily) CDX index"
+      task :level1 do
+        rollup(0)
+      end
+
+      desc "Rollup Level1 (daily) into Level2 (monthly) CDX index"
+      task :level2 do
+        rollup(1)
+      end
+
+      desc "Rollup Level2 (monthly) into Level3 (yearly) CDX index"
+      task :level3 do
+        rollup(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is connected to #47 and implements rake tasks that will rollup the CDX indexes using a Level 0 > 1 > 2 > 3 scheme.  On deploy, it will eventually (commented out right now) create cronjobs to do the rollup on time-based intervals.

NOTE: That `ROBOT_ENVIRONMENT=xxx` is now _required_ to run rake tasks

The new rake tasks are:

```
rake cdx:index:admin:lockfile:remove  # Remove a stale lockfile
rake cdx:index:admin:lockfile:show    # Show lockfile
rake cdx:index:admin:migrate  # Migrate old index file into multi-level index files
rake cdx:index:admin:setup    # Setup all CDX indexes (i.e., creates empty file if not present)
rake cdx:index:rollup:level1  # Rollup Level0 (today) into Level1 (daily) CDX index
rake cdx:index:rollup:level2  # Rollup Level1 (daily) into Level2 (monthly) CDX index
rake cdx:index:rollup:level3  # Rollup Level2 (monthly) into Level3 (yearly) CDX index
rake cdx:index:show           # Show all CDX indexes
```

here's a sample usage (note the change migrate through the levels):

```
$ bundle exec rake cdx:index:admin:setup # or cdx:index:admin:migrate
$ echo a > /web-archiving-stacks/data/indices/cdx/level0.cdx
$ bundle exec rake cdx:index:rollup:level1 cdx:index:show
Rolled up level0 into level1 CDX index
-rw-r--r--  1 drh  wheel  0 Dec 20 13:54 /web-archiving-stacks/data/indices/cdx/level0.cdx
-rw-r--r--  1 drh  wheel  2 Dec 20 13:54 /web-archiving-stacks/data/indices/cdx/level1.cdx
-rw-r--r--  1 drh  wheel  0 Dec 20 13:54 /web-archiving-stacks/data/indices/cdx/level2.cdx
-rw-r--r--  1 drh  wheel  0 Dec 20 13:54 /web-archiving-stacks/data/indices/cdx/level3.cdx
$ bundle exec rake cdx:index:rollup:level2 cdx:index:show
Rolled up level1 into level2 CDX index
-rw-r--r--  1 drh  wheel  0 Dec 20 13:54 /web-archiving-stacks/data/indices/cdx/level0.cdx
-rw-r--r--  1 drh  wheel  0 Dec 20 13:55 /web-archiving-stacks/data/indices/cdx/level1.cdx
-rw-r--r--  1 drh  wheel  2 Dec 20 13:55 /web-archiving-stacks/data/indices/cdx/level2.cdx
-rw-r--r--  1 drh  wheel  0 Dec 20 13:54 /web-archiving-stacks/data/indices/cdx/level3.cdx
$ bundle exec rake cdx:index:rollup:level3 cdx:index:show
Rolled up level2 into level3 CDX index
-rw-r--r--  1 drh  wheel  0 Dec 20 13:54 /web-archiving-stacks/data/indices/cdx/level0.cdx
-rw-r--r--  1 drh  wheel  0 Dec 20 13:55 /web-archiving-stacks/data/indices/cdx/level1.cdx
-rw-r--r--  1 drh  wheel  0 Dec 20 13:55 /web-archiving-stacks/data/indices/cdx/level2.cdx
-rw-r--r--  1 drh  wheel  2 Dec 20 13:55 /web-archiving-stacks/data/indices/cdx/level3.cdx
```