### PR TITLE
[WIP] add honeybadger for Resque jobs

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -23,6 +23,7 @@ require 'capistrano/bundler'
 
 require 'dlss/capistrano'
 require 'whenever/capistrano'
+require 'capistrano/honeybadger'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'assembly-image' # was-seed-preassembly thumbnail creation
 gem 'rest-client'    # was-seed-dissemination does direct call to Dor rest service???
 gem 'pry', '~> 0.10.1'          # for bin/console
 gem 'slop'                      # for bin/run_robot
+gem 'honeybadger', '~> 2.0'
 
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
+    honeybadger (2.7.2)
     hooks (0.3.6)
       uber (~> 0.0.4)
     http-cookie (1.0.2)
@@ -339,6 +340,7 @@ DEPENDENCIES
   dor-services (~> 5.8, >= 5.8.2)
   druid-tools
   equivalent-xml
+  honeybadger (~> 2.0)
   lyber-core (~> 4.0, >= 4.0.3)
   mini_exiftool
   mini_magick

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,7 +21,7 @@ set :deploy_to, "/opt/app/was/#{fetch(:application)}"
 # set :pty, true
 
 # Default value for :linked_files is []
-# set :linked_files, %w{config/database.yml}
+set :linked_files, %w(config/honeybadger.yml)
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -4,5 +4,6 @@ Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'development'
 set :whenever_environment, fetch(:deploy_environment)
+set :honeybadger_env, fetch(:deploy_environment)
 set :default_env, { robot_environment: fetch(:deploy_environment) }
 set :bundle_without, %w{deployment test}.join(' ')

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,5 +4,6 @@ Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'production'
 set :whenever_environment, fetch(:deploy_environment)
+set :honeybadger_env, fetch(:deploy_environment)
 set :default_env, { robot_environment: fetch(:deploy_environment) }
 set :bundle_without, %w{deployment development test}.join(' ')

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -4,5 +4,6 @@ Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'test'
 set :whenever_environment, fetch(:deploy_environment)
+set :honeybadger_env, fetch(:deploy_environment)
 set :default_env, { robot_environment: fetch(:deploy_environment) }
 set :bundle_without, %w{deployment test}.join(' ')

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,0 +1,4 @@
+---
+api_key: 'your-api-key'
+exceptions:
+  rescue_rake: true


### PR DESCRIPTION
This PR fixes https://github.com/sul-dlss/was_robot_suite/issues/55. Honeybadger natively supports Resque so we don't need any initialization or `Honeybadger.notify` code added.