### PR TITLE
fix how to get collection_id after ActiveFedora upgrade

### DIFF
--- a/lib/was_crawl_dissemination/utilities.rb
+++ b/lib/was_crawl_dissemination/utilities.rb
@@ -15,11 +15,7 @@ module Dor
         end
 
         def self.get_collection_id(druid_obj)
-          collections = druid_obj.collections
-          fail "#{druid_obj.id} doesn't belong to a collection" if collections.length == 0
-
-          collection = collections[0]
-          collection.id.sub('druid:', '')
+          Dor::WASCrawl::Utilities.get_collection_id(druid_obj)
         end
       end
     end

--- a/lib/was_crawl_preassembly/utilities.rb
+++ b/lib/was_crawl_preassembly/utilities.rb
@@ -2,10 +2,10 @@ module Dor
   module WASCrawl
     class Utilities
       def self.get_collection_id(druid_obj)
-        collections = druid_obj.collections
-        raise "#{druid_obj.id} doesn't belong to a collection" if collections.length == 0
-        collection = collections[0]
+        collection = druid_obj.collections.first
         collection.id.sub('druid:', '')
+      rescue => e
+        raise "#{druid_obj.id} doesn't belong to a collection (#{e.message})"
       end
 
       def self.get_crawl_id(druid_obj)

--- a/spec/wasCrawlDissemination/utilities_spec.rb
+++ b/spec/wasCrawlDissemination/utilities_spec.rb
@@ -37,4 +37,11 @@ describe Dor::WASCrawl::Dissemination::Utilities do
       expect(file_list.length).to eq(0)
     end
   end
+  context '.get_collection_id' do
+    let(:druid_obj) { double(Dor::Item) }
+    it 'delegates to Dor::WASCrawl::Utilities' do
+      expect(Dor::WASCrawl::Utilities).to receive(:get_collection_id).with(druid_obj).and_return('abc')
+      expect(described_class.get_collection_id(druid_obj)).to eq 'abc'
+    end
+  end
 end

--- a/spec/wasCrawlPreassembly/lib/utilities_spec.rb
+++ b/spec/wasCrawlPreassembly/lib/utilities_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Dor::WASCrawl::Utilities do
+  let(:druid) { 'druid:aa111bb2222' }
+  let(:druid_obj) { Dor.find(druid) }
+  let(:collections) { double(ActiveFedora::Associations::CollectionProxy) }
+  before do
+    allow(Dor).to receive(:find).and_return(double(Dor::Item, id: druid))
+  end
+  context 'collections' do
+    let(:collection_druid) { 'druid:cc333dd4444' }
+    let(:collection) { double(Dor::Collection, id: collection_druid) }
+    before do
+      expect(druid_obj).to receive(:collections).and_return(collections)
+    end
+    it 'fetches a collection id' do
+      expect(collections).to receive(:first).and_return(collection)
+      expect(subject.class.get_collection_id(druid_obj)).to eq 'cc333dd4444'
+    end
+    it 'handles no collections' do
+      expect(collections).to receive(:first).and_return(nil)
+      expect(druid_obj).to receive(:id)
+      expect { subject.class.get_collection_id(druid_obj) }.to raise_error(RuntimeError, /aa111bb2222 doesn't belong to a collection/)
+    end
+  end
+  it 'dies if ActiveFedora API changes' do
+    expect(druid_obj).to receive(:collections).and_return(nil)
+    expect(druid_obj).to receive(:id)
+    expect { subject.class.get_collection_id(druid_obj) }.to raise_error(RuntimeError, /aa111bb2222 doesn't belong to a collection/)
+  end
+end


### PR DESCRIPTION
This PR fixes this error in 2 crawl robots -- metadata-extractor and cdx-generator:

```
undefined method `length' for #<ActiveFedora::Associations::HasAndBelongsToManyAssociation:0x00000003af1380>
```

Note that `get_collection_id` is implemented in TWO places, so I delegated one of them. I also wrote full specs for that code.