### PR TITLE
use robot_environment for all cronjobs

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,6 @@
 set :output, 'log/cdx_index_rollup.log'
+set :environment_variable, 'ROBOT_ENVIRONMENT'
+
 every 1.day, roles: [:rollup] do
   rake 'cdx:index:rollup:level1'
 end
@@ -14,6 +16,5 @@ end
 every 5.minutes, roles: [:monitor] do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }
-  set :environment_variable, 'ROBOT_ENVIRONMENT'
   rake 'robots:verify'
 end


### PR DESCRIPTION
This PR fixes the cronjob commands so that they set `ROBOT_ENVIRONMENT`, not `RAILS_ENV`