### PR TITLE
Pin rubocop to a known working version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :test do
   gem 'rspec'
   gem 'equivalent-xml'
   gem 'awesome_print'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.40.0'
   gem 'simplecov', require: false
   gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ DEPENDENCIES
   rest-client
   robot-controller (~> 2.1, >= 2.1.1)
   rspec
-  rubocop
+  rubocop (~> 0.40.0)
   simplecov
   slop
 


### PR DESCRIPTION
Updating rubocop without adjusting the configuration causes rubocop errors.