### PR TITLE
travis: only build on deployment version of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.4
   - 2.5.3
 
 env:


### PR DESCRIPTION
ruby version on VMs updated by puppet; only build on deployed version.