### PR TITLE
Prefer dor-workflow-client over dor-services-client to create workflows

### DIFF
--- a/robots/wasCrawlPreassembly/end_was_crawl_preassembly.rb
+++ b/robots/wasCrawlPreassembly/end_was_crawl_preassembly.rb
@@ -1,5 +1,3 @@
-require 'dor/services/client'
-
 module Robots
   module DorRepo
     module WasCrawlPreassembly
@@ -12,21 +10,13 @@ module Robots
         end
 
         def perform(druid)
-          opts = { create_ds: true }
-          opts[:lane_id] = Dor::Config.was_crawl.dedicated_lane.nil? ? 'default' : Dor::Config.was_crawl.dedicated_lane
-          workflow_service.create_workflow('dor', druid, 'accessionWF', initial_workflow, opts)
+          workflow_service.create_workflow_by_name(druid, 'accessionWF', lane_id: lane_id)
         end
 
         private
 
-        def initial_workflow
-          client.workflows.initial(name: 'accessionWF')
-        end
-
-        def client
-          @client ||= Dor::Services::Client.configure(url: Dor::Config.dor_services.url,
-                                                      token: Dor::Config.dor_services.token,
-                                                      token_header: Dor::Config.dor_services.token_header)
+        def lane_id
+          Dor::Config.was_crawl.dedicated_lane || 'default'
         end
       end
     end

--- a/robots/wasSeedPreassembly/end_was_seed_preassembly.rb
+++ b/robots/wasSeedPreassembly/end_was_seed_preassembly.rb
@@ -18,15 +18,23 @@ module Robots
             workflow_service.create_workflow_by_name(druid, 'accessionWF')
           elsif start_completed.eql?('completed') && end_completed.eql?('completed')
             # We need to open a new version
-            dor_service = Dor::Services::Client.object(druid)
-            dor_service.open_new_version
-            dor_service.close_version(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')
+            version_client = client.object(druid).version
+            version_client.open
+            version_client.close(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')
           elsif start_completed.eql?('completed') && !end_completed.eql?('completed')
             # The object is still in accessioning, we have to wait until finish
             fail "Druid object #{druid} is still in accessioning, reset the end-was-seed-preassembly after accessioning completion"
           else
             fail "Druid object #{druid} is unknown status"
           end
+        end
+
+        private
+
+        def client
+          @client ||= Dor::Services::Client.configure(url: Dor::Config.dor_services.url,
+                                                      token: Dor::Config.dor_services.token,
+                                                      token_header: Dor::Config.dor_services.token_header)
         end
       end
     end

--- a/spec/wasSeedPreassembly/robots/end_was_seed_preassembly_spec.rb
+++ b/spec/wasSeedPreassembly/robots/end_was_seed_preassembly_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::WasSeedPreassembly::EndWasSeedPreassembly do
   describe 'perform' do
     let(:druid) { 'druid:ab123cd4567' }
-    let(:service) { instance_double(Dor::Services::Client::Object) }
     let(:instance) { described_class.new }
+    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
 
     subject(:perform) { instance.perform(druid) }
 
     before do
-      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(service)
+      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
       allow(Dor::Config.workflow).to receive(:client).and_return(wf_client)
     end
 
@@ -26,8 +27,8 @@ RSpec.describe Robots::DorRepo::WasSeedPreassembly::EndWasSeedPreassembly do
       let(:wf_client) { instance_double(Dor::Workflow::Client, workflow_status: 'completed') }
 
       it 're-versions the object' do
-        expect(service).to receive(:open_new_version)
-        expect(service).to receive(:close_version).with(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')
+        expect(version_client).to receive(:open)
+        expect(version_client).to receive(:close).with(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')
         perform
       end
     end


### PR DESCRIPTION
Because creating workflows via dor-services-client is deprecated and going away in version 2.0.0. While doing this, move dor-services-client configuration over where it is needed