### PR TITLE
Remove token_header keyword arg when configuring dor-services-client

### DIFF
--- a/config/environments/example.rb
+++ b/config/environments/example.rb
@@ -30,7 +30,6 @@ Dor::Config.configure do
   dor_services do
     url ''
     token ''
-    token_header ''
   end
 
   robots do

--- a/robots/was/robots/base.rb
+++ b/robots/was/robots/base.rb
@@ -7,8 +7,7 @@ module Was
 
       def client
         @client ||= Dor::Services::Client.configure(url: Dor::Config.dor_services.url,
-                                                    token: Dor::Config.dor_services.token,
-                                                    token_header: Dor::Config.dor_services.token_header)
+                                                    token: Dor::Config.dor_services.token)
       end
 
       def seed_uri(druid)


### PR DESCRIPTION
This is no longer required, and in fact can break the client if the header value (from shared_configs) is unset. This is what broke the workflow service connection to dor-services-app.