### PR TITLE
Provide a version when creating a workflow

### DIFF
--- a/robots/was/robots/base.rb
+++ b/robots/was/robots/base.rb
@@ -6,7 +6,19 @@ module Was
       end
 
       def seed_uri(druid)
-        Dor::Services::Client.object(druid).find.label
+        object_client(druid).find.label
+      end
+
+      def object_client(druid)
+        Dor::Services::Client.object(druid)
+      end
+
+      def version_client(druid)
+        object_client(druid).version
+      end
+
+      def current_version(druid)
+        version_client(druid).current.to_i
       end
 
       def workspace_path

--- a/robots/wasCrawlPreassembly/end_was_crawl_preassembly.rb
+++ b/robots/wasCrawlPreassembly/end_was_crawl_preassembly.rb
@@ -10,7 +10,9 @@ module Robots
         end
 
         def perform(druid)
-          workflow_service.create_workflow_by_name(druid, 'accessionWF', lane_id: lane_id)
+          workflow_service.create_workflow_by_name(druid, 'accessionWF',
+                                                   lane_id: lane_id,
+                                                   version: current_version(druid))
         end
 
         private

--- a/robots/wasDissemination/start_special_dissemination.rb
+++ b/robots/wasDissemination/start_special_dissemination.rb
@@ -17,9 +17,9 @@ module Robots
           druid_obj = Dor.find(druid)
           return unless druid_obj.identityMetadata.objectType == ['item'] && !druid_obj.contentMetadata.nil?
           if druid_obj.contentMetadata.contentType == ['webarchive-seed']
-            workflow_service.create_workflow_by_name(druid, 'wasSeedDisseminationWF')
+            workflow_service.create_workflow_by_name(druid, 'wasSeedDisseminationWF', version: current_version(druid))
           elsif druid_obj.contentMetadata.contentType == ['file']
-            workflow_service.create_workflow_by_name(druid, 'wasCrawlDisseminationWF')
+            workflow_service.create_workflow_by_name(druid, 'wasCrawlDisseminationWF', version: current_version(druid))
           end
         end
       end

--- a/robots/wasSeedPreassembly/end_was_seed_preassembly.rb
+++ b/robots/wasSeedPreassembly/end_was_seed_preassembly.rb
@@ -15,10 +15,10 @@ module Robots
 
           if start_completed.nil? && end_completed.nil?
             # This object isn't accessioned yet.
-            workflow_service.create_workflow_by_name(druid, 'accessionWF')
+            workflow_service.create_workflow_by_name(druid, 'accessionWF', version: current_version(druid))
           elsif start_completed.eql?('completed') && end_completed.eql?('completed')
             # We need to open a new version
-            version_client = Dor::Services::Client.object(druid).version
+            version_client = version_client(druid)
             version_client.open
             version_client.close(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')
           elsif start_completed.eql?('completed') && !end_completed.eql?('completed')

--- a/spec/wasCrawlPreassembly/robots/end_was_crawl_preassembly_spec.rb
+++ b/spec/wasCrawlPreassembly/robots/end_was_crawl_preassembly_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly do
+RSpec.describe Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly do
   describe '.initialize' do
     it 'initializes the robot with valid parameters' do
       robot = Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly.new
@@ -14,24 +14,25 @@ describe Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly do
     let(:druid) { 'druid:ab123cd4567' }
     let(:workflow_client) { instance_double(Dor::Workflow::Client) }
     let(:workflow_name) { 'accessionWF' }
+    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '5') }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+    let(:robot) { described_class.new }
 
     before do
+      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
       allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
+      allow(workflow_client).to receive(:create_workflow_by_name)
     end
 
     it 'starts the accessionWF on default lane' do
-      allow(workflow_client).to receive(:create_workflow_by_name).with(druid, workflow_name, lane_id: 'default')
-      robot = Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly.new
       robot.perform(druid)
-      expect(workflow_client).to have_received(:create_workflow_by_name).once.with(druid, workflow_name, lane_id: 'default')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, workflow_name, lane_id: 'default', version: 5)
     end
 
     it 'starts the accessionWF on a non-default lane' do
       Settings.was_crawl.dedicated_lane = 'NotDefault'
-      allow(workflow_client).to receive(:create_workflow_by_name).with(druid, workflow_name, lane_id: 'NotDefault')
-      robot = Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly.new
       robot.perform(druid)
-      expect(workflow_client).to have_received(:create_workflow_by_name).once.with(druid, workflow_name, lane_id: 'NotDefault')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, workflow_name, lane_id: 'NotDefault', version: 5)
     end
   end
 end

--- a/spec/wasDissemination/robots/start_special_dissemination_spec.rb
+++ b/spec/wasDissemination/robots/start_special_dissemination_spec.rb
@@ -16,8 +16,13 @@ RSpec.describe Robots::DorRepo::WasDissemination::StartSpecialDissemination do
 
   describe '.perform' do
     subject(:perform) { robot.perform(druid) }
+
+    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '5') }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+
     before do
       allow(Dor).to receive(:find).and_return(druid_obj)
+      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     end
 
     it 'does nothing for collection object' do
@@ -31,14 +36,14 @@ RSpec.describe Robots::DorRepo::WasDissemination::StartSpecialDissemination do
     it 'initializes wasSeedDisseminationWF for webarchive-seed item' do
       allow(druid_obj).to receive_message_chain('identityMetadata.objectType').and_return(['item'])
       allow(contentMetadata).to receive(:contentType).and_return(['webarchive-seed'])
-      expect(robot.workflow_service).to receive(:create_workflow_by_name).with(druid, 'wasSeedDisseminationWF')
+      expect(robot.workflow_service).to receive(:create_workflow_by_name).with(druid, 'wasSeedDisseminationWF', version: 5)
       perform
     end
 
     it 'initializes wasCrawlDisseminationWF for crawl item' do
       allow(druid_obj).to receive_message_chain('identityMetadata.objectType').and_return(['item'])
       allow(contentMetadata).to receive(:contentType).and_return(['file'])
-      expect(robot.workflow_service).to receive(:create_workflow_by_name).with(druid, 'wasCrawlDisseminationWF')
+      expect(robot.workflow_service).to receive(:create_workflow_by_name).with(druid, 'wasCrawlDisseminationWF', version: 5)
       perform
     end
   end

--- a/spec/wasSeedPreassembly/robots/end_was_seed_preassembly_spec.rb
+++ b/spec/wasSeedPreassembly/robots/end_was_seed_preassembly_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Robots::DorRepo::WasSeedPreassembly::EndWasSeedPreassembly do
   describe 'perform' do
     let(:druid) { 'druid:ab123cd4567' }
     let(:instance) { described_class.new }
-    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion) }
+    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '5') }
     let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
 
     subject(:perform) { instance.perform(druid) }
@@ -18,7 +18,7 @@ RSpec.describe Robots::DorRepo::WasSeedPreassembly::EndWasSeedPreassembly do
       let(:wf_client) { instance_double(Dor::Workflow::Client, workflow_status: nil) }
 
       it 'initializes accessionWF' do
-        expect(instance.workflow_service).to receive(:create_workflow_by_name).with(druid, 'accessionWF')
+        expect(instance.workflow_service).to receive(:create_workflow_by_name).with(druid, 'accessionWF', version: 5)
         perform
       end
     end


### PR DESCRIPTION
## Why was this change made?

Not providing one is deprecated

## Was the usage documentation (e.g. README, DevOpsDocs, consul, wiki, queue specific README) updated?
n/a