### PR TITLE
deploy.rb: Actually symlink settings folder.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :linked_files, %w(config/honeybadger.yml)
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-set :linked_dirs, %w(log config/environments config/certs jar tmp)
+set :linked_dirs, %w(log config/environments config/certs config/settings jar tmp)
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
## Why was this change made?

Get the properly settings from shared_configs
