### PR TITLE
Add identifiers to contentMetadata resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ doc/
 
 config/environments/test.rb
 config/environments/dev.rb
-spec/wasSeedPreassembly/fixtures/workspace/aa/111/aa/1111/aa111aa1111/metadata
-spec/wasSeedPreassembly/fixtures/workspace/aa/111/aa/2222/aa111aa2222/metadata
+spec/wasSeedPreassembly/fixtures/workspace

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - 'config/deploy/*.rb'
     - 'config/environments/*.rb'
@@ -9,4 +9,7 @@ AllCops:
 
 # because it's silly to care
 Style/StringLiterals:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -50,10 +50,8 @@ namespace :cdx do
     namespace :rollup do
       def merge(n, src, dst)
         # load required environment variables from configuration file
-        unless Settings.was_crawl_dissemination.sort_env_vars.nil?
-          Settings.was_crawl_dissemination.sort_env_vars.split.each do |statement|
-            ENV[statement.split(/=/).first] = statement.split(/=/).last
-          end
+        Settings.was_crawl_dissemination.sort_env_vars&.split&.each do |statement|
+          ENV[statement.split(/=/).first] = statement.split(/=/).last
         end
 
         # we need to merge the 2 *already sorted* files into the new file, and

--- a/lib/was_crawl_preassembly/content_metadata_generator_service.rb
+++ b/lib/was_crawl_preassembly/content_metadata_generator_service.rb
@@ -16,6 +16,7 @@ module Dor
         write_file_to_druid_metadata_folder(@content_metadata_name, metadata_content)
       end
 
+      # Add some attributes to make the contentMetadata compliant with all SDR contentMetadata
       def do_post_transform(metadata_content)
         # include druid_id in the xml before saving
         metadata_content_xml = Nokogiri::XML(metadata_content)
@@ -23,6 +24,11 @@ module Dor
           raise "The input string is not a valid xml file.\nNokogiri errors: #{metadata_content_xml.errors}\n#{metadata_content_xml}"
         end
         metadata_content_xml.root.set_attribute('id', @druid_id)
+        resources = metadata_content_xml.root.xpath('resource')
+        druid_without_namespace = @druid_id.sub(/^druid:/, '')
+        resources.each.with_index(1) do |resource, i|
+          resource.set_attribute('id', "#{druid_without_namespace}_#{i}")
+        end
         metadata_content_xml.to_s
       end
 

--- a/lib/was_seed_preassembly/content_metadata_generator_service.rb
+++ b/lib/was_seed_preassembly/content_metadata_generator_service.rb
@@ -5,16 +5,13 @@ require 'digest/sha1'
 module Dor
   module WASSeed
     class ContentMetadataGenerator < MetadataGenerator
-      def initialize(workspace, druid_id)
-        super(workspace, druid_id)
-        @content_metadata_name = 'contentMetadata'
-      end
+      CONTENT_METADATA = 'contentMetadata'.freeze
 
       def generate_metadata_output
         xml_input = generate_xml_doc(create_thumbnail_xml_element "#{DruidTools::Druid.new(@druid_id, workspace).content_dir}/thumbnail.jp2")
-        metadata_content = transform_xml_using_xslt(xml_input, read_template(@content_metadata_name))
+        metadata_content = transform_xml_using_xslt(xml_input, read_template(CONTENT_METADATA))
         metadata_content = do_post_transform(metadata_content)
-        write_file_to_druid_metadata_folder(@content_metadata_name, metadata_content)
+        write_file_to_druid_metadata_folder(CONTENT_METADATA, metadata_content)
       end
 
       def generate_xml_doc(image_xml_str = '')

--- a/lib/was_seed_preassembly/metadata_generator_service.rb
+++ b/lib/was_seed_preassembly/metadata_generator_service.rb
@@ -6,10 +6,9 @@ module Dor
       attr_accessor :workspace
       attr_accessor :druid_id
 
-      def initialize(workspace, druid_id)
+      def initialize(workspace, druid_id, _extracted_location = 'tmp/')
         @workspace = workspace
         @druid_id = druid_id
-        @extracted_metadata_xml_location = 'tmp/'
       end
 
       def read_metadata_xml_input_file
@@ -39,6 +38,7 @@ module Dor
         metadata_content.to_s
       end
 
+      # NOP - returns what you pass in
       def do_post_transform(metadata_content)
         metadata_content
       end

--- a/lib/was_seed_preassembly/thumbnail_generator_service.rb
+++ b/lib/was_seed_preassembly/thumbnail_generator_service.rb
@@ -21,7 +21,7 @@ module Dor
           raise "Thumbnail for druid #{druid} and #{uri} can't be generated.\n #{e.message}"
         end
 
-        if result.length > 0 && result.starts_with?('#FAIL#')
+        if result.starts_with?('#FAIL#')
           File.delete(temporary_file + '.jpeg') if File.exist?(temporary_file + '.jpeg')
           fail "Thumbnail for druid #{druid} and #{uri} can't be generated.\n #{result}"
         else

--- a/robots/wasSeedPreassembly/content_metadata_generator.rb
+++ b/robots/wasSeedPreassembly/content_metadata_generator.rb
@@ -12,7 +12,6 @@ module Robots
         def perform(druid)
           workspace_path = Settings.was_seed.workspace_path
           LyberCore::Log.info "Creating ContentMetadataGenerator with parameters  #{workspace_path}, #{druid}"
-
           metadata_generator_service = Dor::WASSeed::ContentMetadataGenerator.new(workspace_path, druid)
           metadata_generator_service.generate_metadata_output
         end

--- a/spec/wasCrawlPreassembly/lib/content_metadata_generator_service_spec.rb
+++ b/spec/wasCrawlPreassembly/lib/content_metadata_generator_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Dor::WASCrawl::ContentMetadataGenerator do
+RSpec.describe Dor::WASCrawl::ContentMetadataGenerator do
   before(:all) do
     @staging_path = Pathname(File.dirname(__FILE__)).join('../fixtures/workspace')
     @extracted_metadata_xml_location = Pathname(File.dirname(__FILE__)).join('../fixtures/xml_extracted_metadata')
@@ -88,19 +88,19 @@ describe Dor::WASCrawl::ContentMetadataGenerator do
     @expected_content_metadata = <<-EOF
 <?xml version="1.0"?>
 <contentMetadata type="file" stacks="/web-archiving-stacks/data/collections/" id="druid:gh123gh1234">
-  <resource type="file">
+  <resource type="file" id="gh123gh1234_1">
     <file dataType="WARC" publish="no" shelve="yes" preserve="yes" id="WARC-Test.warc.gz" size="6608320" mimetype="application/octet-stream">
       <checksum type="MD5">c7edbde066e4697b3f2d823ac42c3692</checksum>
       <checksum type="SHA1">3a9f2ffac1497c70291d93a8bc86c1469547d8f8</checksum>
     </file>
   </resource>
-  <resource type="file">
+  <resource type="file" id="gh123gh1234_2">
     <file dataType="ARC" publish="no" shelve="yes" preserve="yes" id="ARC-Test.arc.gz" size="87846905" mimetype="application/octet-stream">
       <checksum type="MD5">f05e6759eeebbed5e17266809872c9f3</checksum>
       <checksum type="SHA1">e4fd69c988b5abb5d082e4ec897a582d74dc2bbf</checksum>
     </file>
   </resource>
-  <resource type="file">
+  <resource type="file" id="gh123gh1234_3">
     <file dataType="general" publish="no" shelve="no" preserve="yes" id="test.txt" size="4" mimetype="text/plain">
       <checksum type="MD5">e2fc714c4727ee9395f324cd2e7f331f</checksum>
       <checksum type="SHA1">81fe8bfe87576c3ecb22426f8e57847382917acf</checksum>

--- a/spec/wasSeedPreassembly/lib/content_metadata_generator_service_spec.rb
+++ b/spec/wasSeedPreassembly/lib/content_metadata_generator_service_spec.rb
@@ -1,26 +1,47 @@
 require 'spec_helper'
-require 'was_seed_preassembly/content_metadata_generator_service'
-require 'equivalent-xml'
 
-describe Dor::WASSeed::ContentMetadataGenerator do
+RSpec.describe Dor::WASSeed::ContentMetadataGenerator do
   before(:all) do
     @staging_path = Pathname(File.dirname(__FILE__)).join('../fixtures/')
     @expected_thumbnal_xml_element = '<image><md5>cecab42610cefd7f8ba80c8505a0f95f</md5><sha1>c78e5e8e8ca02c6fffa9169b0e9e4df908675fdc</sha1><size>228709</size><width>1000</width><height>1215</height></image>'
     @expected_full_xml_element  = Nokogiri::XML("<item><druid>druid:aa111aa1111</druid>#{@expected_thumbnal_xml_element}</item>")
     @expected_empty_xml_element = Nokogiri::XML('<item><druid>druid:aa111aa1111</druid></item>')
-    @contnet_metadata_full = '<contentMetadata type="webarchive-seed" id="druid:aa111aa1111">
-  <resource type="image" sequence="1">
-    <file preserve="no" publish="yes" shelve="yes" mimetype="image/jp2" id="thumbnail.jp2" size="228709">
-      <checksum type="md5">cecab42610cefd7f8ba80c8505a0f95f</checksum>
-      <checksum type="sha1">c78e5e8e8ca02c6fffa9169b0e9e4df908675fdc</checksum>
-      <imageData width="1000" height="1215"/>
-    </file>
-  </resource>
-</contentMetadata>'
   end
 
-  describe '.generate_metadata_output' do
-    it 'should generate contentMetadata file for a valid druid and valid thumbnail'
+  describe '#generate_metadata_output' do
+    let(:druid_id) { 'druid:gh123gh1234' }
+    let(:workspace) { 'spec/wasSeedPreassembly/fixtures/workspace' }
+    let(:extracted_location) { 'bar' }
+    let(:metadata_generator_service) { described_class.new(workspace, druid_id, extracted_location) }
+    let(:expected_xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <contentMetadata type="webarchive-seed" id="druid:gh123gh1234">
+          <resource type="image" sequence="1" id="gh123gh1234_1">
+            <file preserve="no" publish="yes" shelve="yes" mimetype="image/jp2" id="thumbnail.jp2" size="228709">
+              <checksum type="md5">cecab42610cefd7f8ba80c8505a0f95f</checksum>
+              <checksum type="sha1">c78e5e8e8ca02c6fffa9169b0e9e4df908675fdc</checksum>
+              <imageData width="1000" height="1215"/>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+    let(:stub_exif) { double(MiniExiftool, MIMEType: 'image/jp2', imagewidth: 1000, imageheight: 1215) }
+    before do
+      path = "#{workspace}/gh/123/gh/1234/gh123gh1234/content"
+      FileUtils.mkdir_p(path)
+      FileUtils.cp('spec/wasSeedPreassembly/fixtures/thumbnail_files/thumbnail.jp2', path)
+      allow(MiniExiftool).to receive(:new).and_return(stub_exif)
+    end
+
+    it 'generates contentMetadata file for a valid druid and valid thumbnail' do
+      metadata_generator_service.generate_metadata_output
+
+      expected_output_file = "#{workspace}/gh/123/gh/1234/gh123gh1234/metadata/contentMetadata.xml"
+      actual_content_metadata = File.read(expected_output_file)
+      expect(actual_content_metadata).to eq expected_xml
+    end
   end
 
   describe '.generate_xml_doc' do
@@ -75,10 +96,21 @@ describe Dor::WASSeed::ContentMetadataGenerator do
   end
 
   describe '.transform_xml_using_xslt' do
+    let(:content_metadata_full) do
+      '<contentMetadata type="webarchive-seed" id="druid:aa111aa1111">
+ <resource type="image" sequence="1" id="aa111aa1111_1">
+   <file preserve="no" publish="yes" shelve="yes" mimetype="image/jp2" id="thumbnail.jp2" size="228709">
+     <checksum type="md5">cecab42610cefd7f8ba80c8505a0f95f</checksum>
+     <checksum type="sha1">c78e5e8e8ca02c6fffa9169b0e9e4df908675fdc</checksum>
+     <imageData width="1000" height="1215"/>
+   </file>
+ </resource>
+</contentMetadata>'
+    end
     it 'transforms the xml to content metadata data format using XSLT' do
       xslt_template = File.read(Pathname(File.dirname(__FILE__)).join('../../../template/wasSeedPreassembly/contentMetadata.xslt'))
-      actual_contnet_metadata = cm_generator_instance.transform_xml_using_xslt @expected_full_xml_element, xslt_template
-      expect(Nokogiri::XML(actual_contnet_metadata).to_xml).to eq(Nokogiri::XML(@contnet_metadata_full).to_xml)
+      actual_content_metadata = cm_generator_instance.transform_xml_using_xslt @expected_full_xml_element, xslt_template
+      expect(actual_content_metadata).to be_equivalent_to content_metadata_full
     end
   end
 

--- a/template/wasSeedPreassembly/contentMetadata.xslt
+++ b/template/wasSeedPreassembly/contentMetadata.xslt
@@ -1,13 +1,13 @@
-
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:template match="/item">
-
 	<contentMetadata type="webarchive-seed" >
 		<xsl:attribute name="id">  <xsl:value-of select="druid"/>   </xsl:attribute>
 		<xsl:for-each select="image">
 			<resource type="image" sequence="1">
+				<xsl:attribute name="id">  <xsl:value-of select="concat(substring-after(../druid, ':'), '_1')"/>   </xsl:attribute>
+
 				<file preserve="no" publish="yes" shelve="yes"  mimetype="image/jp2"  id="thumbnail.jp2">
 					<xsl:attribute name="size">  <xsl:value-of select="size"/>   </xsl:attribute>
 					<checksum type="md5"><xsl:value-of select="md5"/></checksum>
@@ -22,4 +22,3 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 	</contentMetadata>
 </xsl:template>
 </xsl:stylesheet>
-


### PR DESCRIPTION
## Why was this change made?
These identifiers are required when mapping resources to cocina

Fixes #188 

## Was the usage documentation (e.g. README, DevOpsDocs, consul, wiki, queue specific README) updated?

n/a


## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
