### PR TITLE
Use item.label instead of identityMetadata when generating descMd

### DIFF
--- a/lib/was_crawl_preassembly/desc_metadata_generator_service.rb
+++ b/lib/was_crawl_preassembly/desc_metadata_generator_service.rb
@@ -18,10 +18,7 @@ module Dor
 
       def generate_xml_doc
         item = Dor.find(@druid_id)
-        identityMetadata = item.datastreams['identityMetadata']
-        title_list = identityMetadata.objectLabel
-        raise "#{@druid_id} identityMetadata doesn't have a valid objectLabel" if title_list.nil? && title_list.empty?
-        "<?xml version=\"1.0\"?><title>#{title_list[0]}</title>"
+        "<?xml version=\"1.0\"?><title>#{item.label}</title>"
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?
Items created from cocina registration do not have the identityMetadata.


## Was the usage documentation (e.g. README, DevOpsDocs, consul, wiki, queue specific README) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.