### PR TITLE
update dor-services-client to v5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'config', '~> 2.0'
 gem 'druid-tools'
 gem 'dor-services', '~> 8.0'
-gem 'dor-services-client', '~> 2.5.1'
+gem 'dor-services-client', '~> 5.1'
 gem 'faraday', '~> 0.15.0'
 gem 'lyber-core', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,11 +60,17 @@ GEM
       resque-pool
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.1.2)
+    cocina-models (0.31.1)
+      activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
+      openapi3_parser
+      openapi_parser
+      thor
       zeitwerk (~> 2.1)
     coderay (1.1.2)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.1.6)
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -102,12 +108,12 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (2.5.1)
+    dor-services-client (5.1.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.1.0)
-      faraday (~> 0.15)
+      cocina-models (~> 0.31.0)
+      deprecation
+      faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
-      nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
     dor-workflow-client (3.21.0)
       activesupport (>= 3.2.1, < 7)
@@ -231,6 +237,10 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
+    openapi3_parser (0.8.0)
+      commonmarker (~> 0.17)
+      psych (~> 3.1)
+    openapi_parser (0.10.0)
     parallel (1.19.1)
     parser (2.7.1.0)
       ast (~> 2.4.0)
@@ -242,6 +252,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    psych (3.1.0)
     rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
@@ -308,6 +319,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-enum (0.8.0)
+      i18n
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rubydora (2.1.0)
@@ -374,7 +387,7 @@ DEPENDENCIES
   config (~> 2.0)
   dlss-capistrano
   dor-services (~> 8.0)
-  dor-services-client (~> 2.5.1)
+  dor-services-client (~> 5.1)
   druid-tools
   equivalent-xml
   faraday (~> 0.15.0)


### PR DESCRIPTION
## Why was this change made?

So we can more easily upgrade all our apps at once to use the exact same version of cocina-models (which is pinned in dor-services-client)

- note:  dsc is only used for versioning:

```
$ ack client  lib/ robots/
robots/wasCrawlPreassembly/end_was_crawl_preassembly.rb
13:          object_client = Dor::Services::Client.object(druid)
14:          current_version = object_client.version.current

robots/wasDissemination/start_special_dissemination.rb
20:          object_client = Dor::Services::Client.object(druid)
21:          current_version = object_client.version.current

robots/wasSeedPreassembly/end_was_seed_preassembly.rb
13:          object_client = Dor::Services::Client.object(druid)
14:          version_client = object_client.version
15:          current_version = version_client.current
25:            version_client.open
26:            version_client.close(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')

robots/was/robots/base.rb
5:        Dor::Config.workflow.client
```

## Was the usage documentation (e.g. README, DevOpsDocs, consul, wiki, queue specific README) updated?

na

## Does this change affect how this application integrates with other services?

na
