### PR TITLE
Added testing of Ruby 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.5.3
+  - 2.7.1
 
 env:
   global:


### PR DESCRIPTION
## Why was this change made?
Added testing of Ruby 2.7.1.


## Was the usage documentation (e.g. README, DevOpsDocs, consul, wiki, queue specific README) updated?



## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
