### PR TITLE
Use cocina to get the default object rights for the APO

### DIFF
--- a/lib/was_crawl_preassembly/content_metadata_generator_service.rb
+++ b/lib/was_crawl_preassembly/content_metadata_generator_service.rb
@@ -33,11 +33,12 @@ module Dor
       end
 
       def template_suffix
-        druid_obj = Dor.find @druid_id
-        admin_policy = druid_obj.admin_policy_object
-        default_rights_md = admin_policy.datastreams['defaultObjectRights'].content
-        # If the read access is anything otherthan world, it's dark.
-        Nokogiri::XML(default_rights_md).xpath('//access[@type="read"]/machine/world').first.nil? ? 'dark' : 'public'
+        object_client = Dor::Services::Client.object(@druid_id)
+        cocina_model = object_client.find
+        apo = Dor::Services::Client.object(cocina_model.administrative.hasAdminPolicy).find
+        default_rights_xml = apo.administrative.defaultObjectRights
+        # If the read access is anything other than world, it's dark.
+        Nokogiri::XML(default_rights_xml).xpath('//access[@type="read"]/machine/world').first.nil? ? 'dark' : 'public'
       end
     end
   end

--- a/lib/was_crawl_preassembly/content_metadata_generator_service.rb
+++ b/lib/was_crawl_preassembly/content_metadata_generator_service.rb
@@ -33,9 +33,8 @@ module Dor
       end
 
       def template_suffix
-        object_client = Dor::Services::Client.object(@druid_id)
-        cocina_model = object_client.find
-        apo = Dor::Services::Client.object(cocina_model.administrative.hasAdminPolicy).find
+        dro = Dor::Services::Client.object(@druid_id).find
+        apo = Dor::Services::Client.object(dro.administrative.hasAdminPolicy).find
         default_rights_xml = apo.administrative.defaultObjectRights
         # If the read access is anything other than world, it's dark.
         Nokogiri::XML(default_rights_xml).xpath('//access[@type="read"]/machine/world').first.nil? ? 'dark' : 'public'

--- a/lib/was_crawl_preassembly/desc_metadata_generator_service.rb
+++ b/lib/was_crawl_preassembly/desc_metadata_generator_service.rb
@@ -17,7 +17,7 @@ module Dor
       end
 
       def generate_xml_doc
-        item = Dor.find(@druid_id)
+        item = Dor::Services::Client.object(@druid_id).find
         "<?xml version=\"1.0\"?><title>#{item.label}</title>"
       end
     end

--- a/lib/was_crawl_preassembly/utilities.rb
+++ b/lib/was_crawl_preassembly/utilities.rb
@@ -1,11 +1,12 @@
 module Dor
   module WASCrawl
     class Utilities
-      def self.get_collection_id(druid_obj)
-        collection = druid_obj.collections.first
-        collection.id.sub('druid:', '')
-      rescue => e
-        raise "#{druid_obj.id} doesn't belong to a collection (#{e.message})"
+      # @param [Cocina::Models::DRO] cocina_model
+      def self.get_collection_id(cocina_model)
+        collection = cocina_model.structural.isMemberOf
+        raise "#{cocina_model.externalIdentifier} doesn't belong to a collection" unless collection
+
+        collection.delete_prefix('druid:')
       end
 
       def self.get_crawl_id(druid_obj)

--- a/lib/was_crawl_preassembly/utilities.rb
+++ b/lib/was_crawl_preassembly/utilities.rb
@@ -9,7 +9,8 @@ module Dor
         collection.delete_prefix('druid:')
       end
 
-      def self.get_crawl_id(druid_obj)
+      # @param [Cocina::Models::DRO] cocina_model
+      def self.get_crawl_id(_cocina_model)
         druid_obj.label
       end
     end

--- a/lib/was_crawl_preassembly/utilities.rb
+++ b/lib/was_crawl_preassembly/utilities.rb
@@ -10,8 +10,8 @@ module Dor
       end
 
       # @param [Cocina::Models::DRO] cocina_model
-      def self.get_crawl_id(_cocina_model)
-        druid_obj.label
+      def self.get_crawl_id(cocina_model)
+        cocina_model.label
       end
     end
   end

--- a/robots/wasCrawlDissemination/cdx_generator.rb
+++ b/robots/wasCrawlDissemination/cdx_generator.rb
@@ -16,7 +16,9 @@ module Robots
         # @param [String] druid -- the Druid identifier for the object to process
         def perform(druid)
           druid_obj = Dor.find(druid)
-          collection_id = Dor::WASCrawl::Dissemination::Utilities.get_collection_id(druid_obj)
+          cocina_object = Dor::Services::Client.object(druid).find
+
+          collection_id = Dor::WASCrawl::Dissemination::Utilities.get_collection_id(cocina_object)
           collection_path = Settings.was_crawl_dissemination.stacks_collections_path + collection_id
           contentMetadata = druid_obj.datastreams['contentMetadata']
 

--- a/robots/wasCrawlDissemination/path_indexer.rb
+++ b/robots/wasCrawlDissemination/path_indexer.rb
@@ -16,7 +16,9 @@ module Robots
         # @param [String] druid -- the Druid identifier for the object to process
         def perform(druid)
           druid_obj = Dor.find(druid)
-          collection_id = Dor::WASCrawl::Dissemination::Utilities.get_collection_id(druid_obj)
+          cocina_object = Dor::Services::Client.object(druid).find
+
+          collection_id = Dor::WASCrawl::Dissemination::Utilities.get_collection_id(cocina_object)
           collection_path = Settings.was_crawl_dissemination.stacks_collections_path + collection_id
           contentMetadata = druid_obj.datastreams['contentMetadata']
           path_working_directory = Settings.was_crawl_dissemination.path_working_directory

--- a/robots/wasCrawlPreassembly/build_was_crawl_druid_tree.rb
+++ b/robots/wasCrawlPreassembly/build_was_crawl_druid_tree.rb
@@ -12,8 +12,9 @@ module Robots
         end
 
         def perform(druid)
-          druid_obj = Dor.find(druid)
-          crawl_id = Dor::WASCrawl::Utilities.get_crawl_id(druid_obj)
+          cocina_model = Dor::Services::Client.object(druid).find
+
+          crawl_id = Dor::WASCrawl::Utilities.get_crawl_id(cocina_model)
           source_root_pathname = Settings.was_crawl.source_path
           staging_path = Settings.was_crawl.staging_path
 

--- a/robots/wasCrawlPreassembly/build_was_crawl_druid_tree.rb
+++ b/robots/wasCrawlPreassembly/build_was_crawl_druid_tree.rb
@@ -15,7 +15,6 @@ module Robots
           druid_obj = Dor.find(druid)
           crawl_id = Dor::WASCrawl::Utilities.get_crawl_id(druid_obj)
           source_root_pathname = Settings.was_crawl.source_path
-          # collection_id = Dor::WASCrawl::Utilities.get_collection_id(druid_obj)
           staging_path = Settings.was_crawl.staging_path
 
           druid_tree_directory = DruidTools::Druid.new(druid, staging_path)

--- a/robots/wasCrawlPreassembly/content_metadata_generator.rb
+++ b/robots/wasCrawlPreassembly/content_metadata_generator.rb
@@ -12,9 +12,10 @@ module Robots
         end
 
         def perform(druid)
-          druid_obj = Dor.find(druid)
+          cocina_model = Dor::Services::Client.object(druid).find
+
           # Fill the input parameters
-          collection_id = Dor::WASCrawl::Utilities.get_collection_id(druid_obj)
+          collection_id = Dor::WASCrawl::Utilities.get_collection_id(cocina_model)
           staging_path = Settings.was_crawl.staging_path
 
           LyberCore::Log.info "Creating ContentMetadataGenerator with parameters #{collection_id}, #{staging_path}, #{druid}"

--- a/robots/wasCrawlPreassembly/desc_metadata_generator.rb
+++ b/robots/wasCrawlPreassembly/desc_metadata_generator.rb
@@ -10,9 +10,10 @@ module Robots
         end
 
         def perform(druid)
-          druid_obj = Dor.find(druid)
+          cocina_model = Dor::Services::Client.object(druid).find
+
           # Fill the input parameters
-          collection_id = Dor::WASCrawl::Utilities.get_collection_id(druid_obj)
+          collection_id = Dor::WASCrawl::Utilities.get_collection_id(cocina_model)
           staging_path = Settings.was_crawl.staging_path
 
           LyberCore::Log.info "Creating DescMetadataGenerator with parameters #{collection_id}, #{staging_path}, #{druid}"

--- a/robots/wasCrawlPreassembly/metadata_extractor.rb
+++ b/robots/wasCrawlPreassembly/metadata_extractor.rb
@@ -11,9 +11,11 @@ module Robots
         end
 
         def perform(druid)
+          cocina_model = Dor::Services::Client.object(druid).find
+
           druid_obj = Dor.find(druid)
           # Fill the input parameters
-          collection_id = Dor::WASCrawl::Utilities.get_collection_id(druid_obj)
+          collection_id = Dor::WASCrawl::Utilities.get_collection_id(cocina_model)
           crawl_id = Dor::WASCrawl::Utilities.get_crawl_id(druid_obj)
           staging_path = Settings.was_crawl.staging_path
 

--- a/robots/wasCrawlPreassembly/metadata_extractor.rb
+++ b/robots/wasCrawlPreassembly/metadata_extractor.rb
@@ -13,10 +13,9 @@ module Robots
         def perform(druid)
           cocina_model = Dor::Services::Client.object(druid).find
 
-          druid_obj = Dor.find(druid)
           # Fill the input parameters
           collection_id = Dor::WASCrawl::Utilities.get_collection_id(cocina_model)
-          crawl_id = Dor::WASCrawl::Utilities.get_crawl_id(druid_obj)
+          crawl_id = Dor::WASCrawl::Utilities.get_crawl_id(cocina_model)
           staging_path = Settings.was_crawl.staging_path
 
           LyberCore::Log.info "Creating MetadataExtractor with parameters #{collection_id}, #{crawl_id}, #{staging_path}, #{druid}"

--- a/robots/wasCrawlPreassembly/technical_metadata_generator.rb
+++ b/robots/wasCrawlPreassembly/technical_metadata_generator.rb
@@ -10,9 +10,10 @@ module Robots
         end
 
         def perform(druid)
-          druid_obj = Dor.find(druid)
+          cocina_model = Dor::Services::Client.object(druid).find
+
           # Fill the input parameters
-          collection_id = Dor::WASCrawl::Utilities.get_collection_id(druid_obj)
+          collection_id = Dor::WASCrawl::Utilities.get_collection_id(cocina_model)
           staging_path = Settings.was_crawl.staging_path
 
           LyberCore::Log.info "Creating TechnicalMetadataGenerator with parameters #{collection_id}, #{staging_path}, #{druid}"

--- a/robots/wasSeedDissemination/update_thumbnail_generator.rb
+++ b/robots/wasSeedDissemination/update_thumbnail_generator.rb
@@ -18,8 +18,7 @@ module Robots
         def perform(druid)
           druid_obj = Dor.find(druid)
           original_uri = get_original_uri(druid_obj.datastreams['descMetadata'].ng_xml)
-          druid_id = druid_obj.id.split(':').last
-          send_to_thumbnail_generator(druid_id, original_uri)
+          send_to_thumbnail_generator(druid.delete_prefix('druid:'), original_uri)
         end
 
         def get_original_uri(descMetadata_ng)

--- a/spec/wasCrawlPreassembly/lib/utilities_spec.rb
+++ b/spec/wasCrawlPreassembly/lib/utilities_spec.rb
@@ -1,31 +1,26 @@
 require 'spec_helper'
 
-describe Dor::WASCrawl::Utilities do
+RSpec.describe Dor::WASCrawl::Utilities do
   let(:druid) { 'druid:aa111bb2222' }
-  let(:druid_obj) { Dor.find(druid) }
-  let(:collections) { double(ActiveFedora::Associations::CollectionProxy) }
-  before do
-    allow(Dor).to receive(:find).and_return(double(Dor::Item, id: druid))
+  let(:collection_druid) { 'druid:cc333dd4444' }
+
+  let(:cocina_model) do
+    instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural: structural)
   end
-  context 'collections' do
-    let(:collection_druid) { 'druid:cc333dd4444' }
-    let(:collection) { double(Dor::Collection, id: collection_druid) }
-    before do
-      expect(druid_obj).to receive(:collections).and_return(collections)
-    end
+
+  context 'when the object belongs to a collection' do
+    let(:structural) { instance_double(Cocina::Models::DROStructural, isMemberOf: collection_druid) }
+
     it 'fetches a collection id' do
-      expect(collections).to receive(:first).and_return(collection)
-      expect(subject.class.get_collection_id(druid_obj)).to eq 'cc333dd4444'
-    end
-    it 'handles no collections' do
-      expect(collections).to receive(:first).and_return(nil)
-      expect(druid_obj).to receive(:id)
-      expect { subject.class.get_collection_id(druid_obj) }.to raise_error(RuntimeError, /aa111bb2222 doesn't belong to a collection/)
+      expect(described_class.get_collection_id(cocina_model)).to eq 'cc333dd4444'
     end
   end
-  it 'dies if ActiveFedora API changes' do
-    expect(druid_obj).to receive(:collections).and_return(nil)
-    expect(druid_obj).to receive(:id)
-    expect { subject.class.get_collection_id(druid_obj) }.to raise_error(RuntimeError, /aa111bb2222 doesn't belong to a collection/)
+
+  context 'when the object does not belong to a collection' do
+    let(:structural) { instance_double(Cocina::Models::DROStructural, isMemberOf: nil) }
+
+    it 'raises an error' do
+      expect { described_class.get_collection_id(cocina_model) }.to raise_error(RuntimeError, /aa111bb2222 doesn't belong to a collection/)
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Migrate away from direct Fedora access.

## Was the usage documentation (e.g. README, DevOpsDocs, consul, wiki, queue specific README) updated?

no
