### PR TITLE
update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,10 @@
 
 
 
-## Was the usage documentation (e.g. README, DevOpsDocs, consul, wiki, queue specific README) updated?
+## How was this change tested?
+- test code in this repo, infra-integration-tests, manually on [laptop|stage|qa], vetted by PO in [stage|qa] ...
 
 
 
-## Does this change affect how this application integrates with other services?
-If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
+## Which documentation and/or configurations were updated?
+- README, DevOpsDocs, shared_configs, workflow-server-rails conifgs, wiki, ...


### PR DESCRIPTION
## Why was this change made?

in the hopes of getting
- better communication between PR author and reviewers
- better "stop and think" moments about testing and documentation from both PR authors and reviewers

## How was this change tested?
- test code in this repo, infra-integration-tests, manually on [laptop|stage|qa], vetted by PO in [stage|qa] ...

I asked for review of the new template from infrastructure team

## Which documentation and/or configurations were updated?
- README, DevOpsDocs, shared_configs, wiki, ...

n/a