### PR TITLE
Upgrade honeybadger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'assembly-image' # was-seed-preassembly thumbnail creation
 gem 'rest-client'    # was-seed-dissemination to call was-thumbnail-service
 gem 'pry'            # for bin/console
 gem 'slop'           # for bin/run_robot
-gem 'honeybadger', '~> 2.0'
+gem 'honeybadger'
 # iso-639 0.3.0 isn't compatible with ruby 2.5.  This declaration can be dropped when we upgrade to 2.6
 gem 'iso-639', '~> 0.2.8'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
-    honeybadger (2.7.2)
+    honeybadger (4.6.0)
     hooks (0.4.1)
       uber (~> 0.0.14)
     htmlentities (4.3.4)
@@ -392,7 +392,7 @@ DEPENDENCIES
   druid-tools
   equivalent-xml
   faraday (~> 0.15.0)
-  honeybadger (~> 2.0)
+  honeybadger
   iso-639 (~> 0.2.8)
   lockfile
   lyber-core (~> 5.0)


### PR DESCRIPTION
## Why was this change made?

The 2.0 version of Honeybadger is no longer reporting errors to the server.

## How was this change tested?



## Which documentation and/or configurations were updated?



