### PR TITLE
Do dependency injection of the warc file list

### DIFF
--- a/lib/was_crawl_dissemination/cdx_generator_service.rb
+++ b/lib/was_crawl_dissemination/cdx_generator_service.rb
@@ -1,8 +1,8 @@
 module Dor
   module WASCrawl
     class CDXGeneratorService
-      def initialize(collection_path, druid_id, contentMetadata)
-        @contentMetadata = contentMetadata
+      def initialize(collection_path, druid_id, warc_file_list)
+        @warc_file_list = warc_file_list
         @druid_id = druid_id
         @collection_path = collection_path
         @cdx_indexer_script_file_name = Settings.was_crawl_dissemination.cdx_indexer_script
@@ -12,11 +12,10 @@ module Dor
       end
 
       def generate_cdx_for_crawl
-        warc_file_list = Dor::WASCrawl::Dissemination::Utilities.get_warc_file_list_from_content_metadata(@contentMetadata)
         cdx_druid_dir = "#{@cdx_working_directory}/#{@druid_id}"
         FileUtils.makedirs cdx_druid_dir unless File.exist?(cdx_druid_dir)
         druid_base_directory = DruidTools::AccessDruid.new(@druid_id, @collection_path).path
-        warc_file_list.each do |warc_file_name|
+        @warc_file_list.each do |warc_file_name|
           cdx_file_name  = get_cdx_file_name(warc_file_name)
           cdx_file_path  = "#{cdx_druid_dir}/#{cdx_file_name}"
           warc_file_path = "#{druid_base_directory}/#{warc_file_name}"

--- a/lib/was_crawl_dissemination/path_indexer_service.rb
+++ b/lib/was_crawl_dissemination/path_indexer_service.rb
@@ -1,9 +1,9 @@
 module Dor
   module WASCrawl
     class PathIndexerService
-      def initialize(druid_id, collection_path, path_working_directory, contentMetadata)
+      def initialize(druid_id, collection_path, path_working_directory, warc_file_list)
         @druid_id = druid_id
-        @contentMetadata = contentMetadata
+        @warc_file_list = warc_file_list
         @collection_path = collection_path
 
         @main_path_index_file = Settings.was_crawl_dissemination.main_path_index_file
@@ -17,10 +17,9 @@ module Dor
         FileUtils.cp_r(@main_path_index_file, @working_merged_path_index)
 
         working_path_index_file = File.open(@working_merged_path_index, 'a')
-        warc_file_list = Dor::WASCrawl::Dissemination::Utilities.get_warc_file_list_from_content_metadata(@contentMetadata)
         druid_base_directory = DruidTools::AccessDruid.new(@druid_id, @collection_path).path
 
-        warc_file_list.each do |warc_file_name|
+        @warc_file_list.each do |warc_file_name|
           record = "#{warc_file_name}\t#{druid_base_directory}/#{warc_file_name}\n"
           working_path_index_file.write(record)
         end

--- a/robots/was_crawl_dissemination/cdx_generator.rb
+++ b/robots/was_crawl_dissemination/cdx_generator.rb
@@ -17,8 +17,9 @@ module Robots
           collection_id = Dor::WASCrawl::Dissemination::Utilities.get_collection_id(cocina_object)
           collection_path = Settings.was_crawl_dissemination.stacks_collections_path + collection_id
           contentMetadata = druid_obj.datastreams['contentMetadata']
+          warc_file_list = Dor::WASCrawl::Dissemination::Utilities.get_warc_file_list_from_content_metadata(contentMetadata.content)
 
-          cdx_generator = Dor::WASCrawl::CDXGeneratorService.new(collection_path, druid, contentMetadata.content)
+          cdx_generator = Dor::WASCrawl::CDXGeneratorService.new(collection_path, druid, warc_file_list)
           cdx_generator.generate_cdx_for_crawl
         end
       end

--- a/robots/was_crawl_dissemination/path_indexer.rb
+++ b/robots/was_crawl_dissemination/path_indexer.rb
@@ -16,10 +16,11 @@ module Robots
 
           collection_id = Dor::WASCrawl::Dissemination::Utilities.get_collection_id(cocina_object)
           collection_path = Settings.was_crawl_dissemination.stacks_collections_path + collection_id
-          contentMetadata = druid_obj.datastreams['contentMetadata']
           path_working_directory = Settings.was_crawl_dissemination.path_working_directory
+          contentMetadata = druid_obj.datastreams['contentMetadata']
+          warc_file_list = Dor::WASCrawl::Dissemination::Utilities.get_warc_file_list_from_content_metadata(contentMetadata.content)
 
-          path_indexer_service = Dor::WASCrawl::PathIndexerService.new(druid, collection_path, path_working_directory, contentMetadata.content)
+          path_indexer_service = Dor::WASCrawl::PathIndexerService.new(druid, collection_path, path_working_directory, warc_file_list)
           path_indexer_service.merge
           path_indexer_service.sort
           path_indexer_service.publish

--- a/spec/was_crawl_dissemination/path_indexer_service_spec.rb
+++ b/spec/was_crawl_dissemination/path_indexer_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Dor::WASCrawl::PathIndexerService do
+RSpec.describe Dor::WASCrawl::PathIndexerService do
   before(:all) do
     @stacks_path = Pathname(File.dirname(__FILE__)).join('fixtures/stacks')
     @path_files = Pathname(File.dirname(__FILE__)).join('fixtures/path_files')
@@ -8,15 +8,16 @@ describe Dor::WASCrawl::PathIndexerService do
     @collection_path = '/wasCrawlDissemination/collections/test_collection'
   end
 
-  describe '.merge' do
+  describe '#merge' do
     before(:all) do
       @druid = 'druid:dd111dd1111'
       @content_metadata_xml_location = 'spec/was_crawl_dissemination/fixtures/metadata/'
     end
+    let(:content_metadata) { File.open(@content_metadata_xml_location + 'contentMetadata_4files.xml').read }
+    let(:warc_file_list) { Dor::WASCrawl::Dissemination::Utilities.get_warc_file_list_from_content_metadata(content_metadata) }
 
-    it 'should merge results from contentMetadata to the main path index' do
-      content_metadata = File.open(@content_metadata_xml_location + 'contentMetadata_4files.xml').read
-      path_index_service = Dor::WASCrawl::PathIndexerService.new(@druid, @collection_path, @path_working_directory, content_metadata)
+    it 'merges results from contentMetadata to the main path index' do
+      path_index_service = Dor::WASCrawl::PathIndexerService.new(@druid, @collection_path, @path_working_directory, warc_file_list)
       path_index_service.instance_variable_set(:@main_path_index_file, "#{@stacks_path}/data/indices/path/path-index.txt")
 
       path_index_service.merge
@@ -33,11 +34,11 @@ describe Dor::WASCrawl::PathIndexerService do
     end
   end
 
-  describe '.sort' do
-    it 'should sort and remove duplicate frm the merged path index' do
+  describe '#sort' do
+    it 'sorts and remove duplicate frm the merged path index' do
       FileUtils.cp("#{@path_files}/merged_path_index.txt", "#{@path_working_directory}/merged_path_index.txt")
 
-      path_index_service = Dor::WASCrawl::PathIndexerService.new(@druid, @collection_path, @path_working_directory, '')
+      path_index_service = Dor::WASCrawl::PathIndexerService.new(@druid, @collection_path, @path_working_directory, [])
       path_index_service.sort
 
       expected_duplicate_path_index = "#{@path_files}/duplicate_path_index.txt"
@@ -58,11 +59,11 @@ describe Dor::WASCrawl::PathIndexerService do
     end
   end
 
-  describe '.publish' do
-    it 'should copy the new path index to the main path index location' do
+  describe '#publish' do
+    it 'copies the new path index to the main path index location' do
       FileUtils.cp("#{@path_files}/path_index.txt", "#{@path_working_directory}/path_index.txt")
 
-      path_index_service = Dor::WASCrawl::PathIndexerService.new(@druid, @collection_path, @path_working_directory, '')
+      path_index_service = Dor::WASCrawl::PathIndexerService.new(@druid, @collection_path, @path_working_directory, [])
       path_index_service.instance_variable_set(:@main_path_index_file, "#{@stacks_path}/data/indices/path/test_path-index.txt")
 
       path_index_service.publish


### PR DESCRIPTION

## Why was this change made?

In this way CDXGeneratorService needs no knowledge of Fedora 3 datastreams.  This will allow us to migrate away from Fedora 3


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

