### PR TITLE
Remove dor when initializing was_crawl_dissemination robots.

### DIFF
--- a/robots/was_crawl_dissemination/cdx_generator.rb
+++ b/robots/was_crawl_dissemination/cdx_generator.rb
@@ -3,7 +3,7 @@ module Robots
     module WasCrawlDissemination
       class CdxGenerator < Was::Robots::Base
         def initialize
-          super('dor', 'wasCrawlDisseminationWF', 'cdx-generator')
+          super('wasCrawlDisseminationWF', 'cdx-generator')
         end
 
         # `perform` is the main entry point for the robot. This is where

--- a/robots/was_crawl_dissemination/cdx_merge_sort_publish.rb
+++ b/robots/was_crawl_dissemination/cdx_merge_sort_publish.rb
@@ -5,7 +5,7 @@ module Robots
     module WasCrawlDissemination
       class CdxMergeSortPublish < Was::Robots::Base
         def initialize
-          super('dor', 'wasCrawlDisseminationWF', 'cdx-merge-sort-publish')
+          super('wasCrawlDisseminationWF', 'cdx-merge-sort-publish')
         end
 
         # `perform` is the main entry point for the robot. This is where

--- a/robots/was_crawl_dissemination/path_indexer.rb
+++ b/robots/was_crawl_dissemination/path_indexer.rb
@@ -3,7 +3,7 @@ module Robots
     module WasCrawlDissemination
       class PathIndexer < Was::Robots::Base
         def initialize
-          super('dor', 'wasCrawlDisseminationWF', 'path-indexer')
+          super('wasCrawlDisseminationWF', 'path-indexer')
         end
 
         # `perform` is the main entry point for the robot. This is where


### PR DESCRIPTION
## Why was this change made?
The initializer for some robots was incorrect.


## How was this change tested?
Stage.


## Which documentation and/or configurations were updated?
No.


