### PR TITLE
remove suri from config files; add qa deploy target

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -64,14 +64,6 @@ Dor::Config.configure do
     key_pass Settings.ssl.key_pass
   end
 
-  suri do
-    mint_ids Settings.suri.mint_ids
-    id_namespace Settings.suri.id_namespace
-    url Settings.suri.url
-    user Settings.suri.user
-    pass Settings.suri.pass
-  end
-
   solr.url Settings.solr.url
 end
 

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,8 @@
+server 'was-robots1-qa.stanford.edu', user: 'was', roles: %w{web app db rollup}
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :deploy_environment, 'production'
+set :whenever_environment, fetch(:deploy_environment)
+set :default_env, { robot_environment: fetch(:deploy_environment) }
+set :bundle_without, %w{deployment test}.join(' ')

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,13 +6,6 @@ ssl:
   key_file: ~
   key_pass: ~
 
-suri:
-  mint_ids: true
-  id_namespace: 'druid'
-  url: ~
-  user: ~
-  pass: ~
-
 solr:
   url: ~
 


### PR DESCRIPTION
## Why was this change made?

- removing cruft from configs avoids confusion
- in the course of checking configurations for suri-rails, it became clear that the shared configs for qa and the deploy target for qa hadn't been done;  I addressed both.

## How was this change tested?

- test suite for config file changes
- I deployed was-robot-suite successfully to qa.  (whether it runs properly or not ... is an exercise left for the reader)

## Which documentation and/or configurations were updated?

shared_configs for qa, for stage, config files in app (see Files changed), and a PR for shared_configs for prod: please merge sul-dlss/shared_configs/pull/1385 after this is merged.


## NOTE:

please merge sul-dlss/shared_configs/pull/1385 after this is merged