### PR TITLE
Drop unnecessary dependency lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,6 @@ gem 'rest-client'    # was-seed-dissemination to call was-thumbnail-service
 gem 'pry'            # for bin/console
 gem 'slop'           # for bin/run_robot
 gem 'honeybadger'
-# iso-639 0.3.0 isn't compatible with ruby 2.5.  This declaration can be dropped when we upgrade to 2.6
-gem 'iso-639', '~> 0.2.8'
 gem 'rake'
 gem 'resque'
 gem 'resque-pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,6 @@ DEPENDENCIES
   equivalent-xml
   faraday (~> 0.15.0)
   honeybadger
-  iso-639 (~> 0.2.8)
   lockfile
   lyber-core (~> 6.0)
   mini_exiftool


### PR DESCRIPTION
## Why was this change made?

No longer needed now that we deploy to ruby 2.6

## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?

n/a

