### PR TITLE
Deletes WARCs after copying to workspace.

### DIFF
--- a/robots/was_crawl_preassembly/build_was_crawl_druid_tree.rb
+++ b/robots/was_crawl_preassembly/build_was_crawl_druid_tree.rb
@@ -12,16 +12,19 @@ module Robots
           cocina_model = Dor::Services::Client.object(druid).find
 
           crawl_id = Dor::WASCrawl::Utilities.get_crawl_id(cocina_model)
-          source_root_pathname = Settings.was_crawl.source_path
+          crawl_directory = File.join(Settings.was_crawl.source_path, crawl_id)
           staging_path = Settings.was_crawl.staging_path
 
           druid_tree_directory = DruidTools::Druid.new(druid, staging_path)
-          LyberCore::Log.info "Copying files from #{source_root_pathname}#{crawl_id}/. to #{druid_tree_directory.content_dir}"
-          Find.find("#{source_root_pathname}#{crawl_id}").each do |single_file|
+          LyberCore::Log.info "Copying files from #{crawl_directory}/. to #{druid_tree_directory.content_dir}"
+          Find.find(crawl_directory).each do |single_file|
             next unless File.file?(single_file)
 
             FileUtils.cp_r single_file, druid_tree_directory.content_dir
           end
+
+          # Deleting after all copied.
+          FileUtils.rm_rf(crawl_directory)
         end
       end
     end

--- a/spec/was_crawl_preassembly/robots/build_was_crawl_druid_tree_spec.rb
+++ b/spec/was_crawl_preassembly/robots/build_was_crawl_druid_tree_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Robots::DorRepo::WasCrawlPreassembly::BuildWasCrawlDruidTree do
+  describe '.initialize' do
+    it 'initializes the robot with valid parameters' do
+      robot = Robots::DorRepo::WasCrawlPreassembly::BuildWasCrawlDruidTree.new
+      expect(robot.instance_variable_get(:@workflow_name)).to eq('wasCrawlPreassemblyWF')
+      expect(robot.instance_variable_get(:@process)).to eq('build-was-crawl-druid-tree')
+    end
+  end
+
+  describe '.perform' do
+    let(:druid) { 'druid:ab123cd4567' }
+    # let(:workflow_client) { instance_double(Dor::Workflow::Client) }
+    # let(:workflow_name) { 'accessionWF' }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, label: 'AIT_123') }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:temp_dir) { Dir.mktmpdir }
+    let(:staging_path) { "#{temp_dir}/workspace" }
+    let(:source_path) { "#{temp_dir}/source" }
+    let(:crawl_path) { "#{source_path}/AIT_123" }
+    # let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
+
+    before do
+      # allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      allow(Settings.was_crawl).to receive(:staging_path).and_return(staging_path)
+      allow(Settings.was_crawl).to receive(:source_path).and_return(source_path)
+
+      FileUtils.mkdir_p(crawl_path)
+      FileUtils.cp("spec/was_crawl_preassembly/fixtures/workspace/test_crawl_object/WARC-Test.warc.gz", crawl_path)
+      FileUtils.mkdir(staging_path)
+    end
+
+    after do
+      FileUtils.rm_rf(temp_dir)
+    end
+
+    it 'copies the files to staging' do
+      robot = Robots::DorRepo::WasCrawlPreassembly::BuildWasCrawlDruidTree.new
+      robot.perform(druid)
+      expect(File.exist?(crawl_path)).to be false
+      expect(File.exist?("#{staging_path}/ab/123/cd/4567/ab123cd4567/content/WARC-Test.warc.gz")).to be true
+    end
+  end
+end


### PR DESCRIPTION
[HOLD per JLitt and Andrew discussing]

closes #245

## Why was this change made?
WARC files are not deleted after copying to accessioning, resulting in disk space filling up.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
No.

