### PR TITLE
Removing fullPage option allows variable sized WARCs to be captured

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -12,7 +12,7 @@ async function run() {
         const page = await browser.newPage();
         await page.setViewport({ width: 1200, height: 800 });
         await page.goto(process.argv[2]);
-        await page.screenshot({ path: process.argv[3], fullPage: true, format: 'jpeg' });
+        await page.screenshot({ path: process.argv[3], format: 'jpeg' });
     } catch (err) {
         console.error(err.message)
     } finally {


### PR DESCRIPTION
## Why was this change made?
Fixes Honeybadger alerts like https://app.honeybadger.io/projects/51141/faults/66136515 and https://app.honeybadger.io/projects/51141/faults/66136139 where the puppeteer screenshot called with `fullPage: true` was preventing the pages to be captured for a thumbnail.

## How was this change tested?
Testing suite.


## Which documentation and/or configurations were updated?
n/a
