### PR TITLE
Stop tests from blowing away .gitkeep dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config/environments/test.rb
 config/environments/dev.rb
 spec/was_seed_preassembly/fixtures/workspace
 node_modules/
+spec/was_crawl_dissemination/fixtures/stacks/data/indices/path_working/*

--- a/spec/was_crawl_dissemination/cdx_merge_sort_publish_service_spec.rb
+++ b/spec/was_crawl_dissemination/cdx_merge_sort_publish_service_spec.rb
@@ -79,43 +79,43 @@ describe Dor::WASCrawl::CDXMergeSortPublishService do
     before(:all) do
       # needs to be @ so after(:all) can access it
       @cdx_backup_dir = "#{@stacks_path}/data/indices/cdx_backup"
+      @druid = 'ii111ii1111'
     end
-    let(:druid) { 'ii111ii1111' }
     it 'moves cdx files to cdx backup directory (from  source_dir)' do
       FileUtils.cp_r("#{cdx_file_path}/ii/.", "#{@cdx_working_dir}")
-      mergeSortPublishService = Dor::WASCrawl::CDXMergeSortPublishService.new(druid, @cdx_working_dir, @cdx_backup_dir)
+      mergeSortPublishService = Dor::WASCrawl::CDXMergeSortPublishService.new(@druid, @cdx_working_dir, @cdx_backup_dir)
 
       expect(File.exist?(mergeSortPublishService.instance_variable_get(:@source_cdx_dir))).to eq true
-      expect(File.exist?("#{@cdx_working_dir}/#{druid}_merged_index.cdx")).to eq true
-      expect(File.exist?("#{@cdx_working_dir}/#{druid}_sorted_duplicate_index.cdx")).to eq true
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}/file1.cdx")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}/file2.cdx")).to eq false
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_merged_index.cdx")).to eq true
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_sorted_duplicate_index.cdx")).to eq true
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to eq false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file1.cdx")).to eq false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file2.cdx")).to eq false
 
       mergeSortPublishService.clean
       expect(File.exist?(mergeSortPublishService.instance_variable_get(:@source_cdx_dir))).to eq false
-      expect(File.exist?("#{@cdx_working_dir}/#{druid}_merged_index.cdx")).to eq false
-      expect(File.exist?("#{@cdx_working_dir}/#{druid}_sorted_duplicate_index.cdx")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}")).to eq true
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}/file1.cdx")).to eq true
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}/file2.cdx")).to eq true
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_merged_index.cdx")).to eq false
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_sorted_duplicate_index.cdx")).to eq false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to eq true
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file1.cdx")).to eq true
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file2.cdx")).to eq true
       # merged_index.cdx and sorted_duplicate_index.cdx are not kept
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}_merged_index.cdx")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}_sorted_duplicate_index.cdx")).to eq false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}_merged_index.cdx")).to eq false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}_sorted_duplicate_index.cdx")).to eq false
     end
 
-    it 'moves cdx files to cdx backup directory when the druid directory already exists' do
+    it 'moves cdx files to cdx backup directory when the @druid directory already exists' do
       FileUtils.cp_r("#{cdx_file_path}/ii/.", "#{@cdx_backup_dir}")
 
-      mergeSortPublishService = Dor::WASCrawl::CDXMergeSortPublishService.new(druid, @cdx_working_dir, @cdx_backup_dir)
-      expect(File.exist?("#{@cdx_backup_dir}/#{druid}")).to eq true
+      mergeSortPublishService = Dor::WASCrawl::CDXMergeSortPublishService.new(@druid, @cdx_working_dir, @cdx_backup_dir)
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to eq true
 
       # it's okay if it complains about the files;  we are specifically concerned about the directory
-      expect { mergeSortPublishService.clean }.not_to raise_error(StandardError, "File exists - #{@cdx_backup_dir}/#{druid}")
+      expect { mergeSortPublishService.clean }.not_to raise_error(StandardError, "File exists - #{@cdx_backup_dir}/#{@druid}")
     end
 
     after(:all) do
-      FileUtils.rm_rf("#{@cdx_backup_dir}/.")
+      FileUtils.rm_rf(Dir.glob("#{@cdx_backup_dir}/#{@druid}*"))
     end
   end
 end

--- a/spec/was_crawl_dissemination/path_indexer_service_spec.rb
+++ b/spec/was_crawl_dissemination/path_indexer_service_spec.rb
@@ -9,13 +9,11 @@ RSpec.describe Dor::WASCrawl::PathIndexerService do
   end
 
   describe '#merge' do
-    before(:all) do
-      @druid = 'druid:dd111dd1111'
-    end
+    let(:druid) { 'druid:dd111dd1111' }
     let(:warc_file_list) { ["WARC-Test.warc.gz", "ARC-Test.arc.gz"] }
 
     it 'merges results from warc_file_list to the main path index' do
-      path_index_service = Dor::WASCrawl::PathIndexerService.new(@druid, @collection_path, @path_working_directory, warc_file_list)
+      path_index_service = Dor::WASCrawl::PathIndexerService.new(druid, @collection_path, @path_working_directory, warc_file_list)
       path_index_service.instance_variable_set(:@main_path_index_file, "#{@stacks_path}/data/indices/path/path-index.txt")
 
       path_index_service.merge
@@ -25,10 +23,6 @@ RSpec.describe Dor::WASCrawl::PathIndexerService do
       expect(File.exist?(actual_merged_file_path)).to eq(true)
 
       expect(File.read(actual_merged_file_path)).to eq(File.read(expected_merged_file_path))
-    end
-
-    after(:all) do
-      FileUtils.rm_rf("#{@path_working_directory}/.")
     end
   end
 
@@ -50,10 +44,6 @@ RSpec.describe Dor::WASCrawl::PathIndexerService do
 
       expect(File.exist?(actual_path_index)).to eq(true)
       expect(File.read(actual_path_index)).to eq(File.read(expected_path_index))
-    end
-
-    after(:all) do
-      FileUtils.rm_rf("#{@path_working_directory}/.")
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

To stop tests from removing dirs under version control.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

