### PR TITLE
Use dlss-capistrano to manage resque-pool

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -23,9 +23,9 @@ require 'capistrano/yarn'
 # require 'capistrano/rails/migrations'
 
 require 'dlss/capistrano'
+require 'dlss/capistrano/resque_pool'
 require 'whenever/capistrano'
 require 'capistrano/honeybadger'
-require 'capistrano-resque-pool'
 
 require "capistrano/scm/git"
 install_plugin Capistrano::SCM::Git

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ end
 
 group :deployment do
   gem 'capistrano-bundler'
-  gem 'capistrano-resque-pool'
   gem 'capistrano-yarn'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,9 +56,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    capistrano-resque-pool (0.2.0)
-      capistrano
-      resque-pool
     capistrano-shared_configs (0.2.2)
     capistrano-yarn (2.0.2)
       capistrano (~> 3.0)
@@ -83,7 +80,7 @@ GEM
     deprecation (0.99.0)
       activesupport
     diff-lcs (1.4.4)
-    dlss-capistrano (3.9.0)
+    dlss-capistrano (3.10.1)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -381,7 +378,6 @@ DEPENDENCIES
   assembly-image
   awesome_print
   capistrano-bundler
-  capistrano-resque-pool
   capistrano-yarn
   config (~> 2.0)
   dlss-capistrano

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,7 +21,7 @@ set :deploy_to, "/opt/app/was/#{fetch(:application)}"
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w(config/honeybadger.yml)
+set :linked_files, %w(config/honeybadger.yml tmp/resque-pool.lock)
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
@@ -63,4 +63,3 @@ set :honeybadger_env, fetch(:stage)
 
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
-after 'deploy:publishing', 'resque:pool:hot_swap'


### PR DESCRIPTION
This replaces capistrano-resque-pool and works as expected with a hot-swappable pool.

Also includes:

Store resque-pool lockfile in shared dir
This allows the resque:pool:hot_swap capistrano task to do what we expect it to do.


