### PR TITLE
Appease rubocop and remove dor-services gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  SuggestExtensions: false
   TargetRubyVersion: 2.6
   Exclude:
     - 'config/deploy/*.rb'
@@ -39,4 +40,65 @@ Style/HashTransformValues:
   Enabled: true
 
 Style/SlicingWithRange:
+  Enabled: true
+
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: true
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+Lint/DeprecatedConstants: # (new in 1.8)
+  Enabled: true
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: true
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: true
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+Lint/TripleQuotes: # (new in 1.9)
+  Enabled: true
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: true
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
+  Enabled: true
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+Style/NilLambda: # (new in 1.3)
+  Enabled: true
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: true
+Style/StringChars: # (new in 1.12)
+  Enabled: true
+Style/SwapValues: # (new in 1.1)
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@ source 'https://rubygems.org'
 
 gem 'config', '~> 2.0'
 gem 'druid-tools'
-gem 'dor-services', '~> 9.0'
 gem 'dor-services-client', '~> 6.0'
 gem 'dor-workflow-client', '~> 3.22'
 gem 'faraday', '~> 0.15.0'
 gem 'lyber-core', '~> 6.0'
+gem 'stanford-mods', '~> 2.6'
 
 gem 'lockfile'       # file locks needed for mutual exclusion during rollup and index addition processes
 gem 'mini_exiftool'  # was-seed-preassembly thumbnail creation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    active-fedora (8.7.0)
-      active-triples (~> 0.4.0)
-      activesupport (>= 4.2.10)
-      deprecation
-      nom-xml (>= 0.5.1)
-      om (~> 3.1)
-      rdf-rdfxml (~> 1.1)
-      rsolr (>= 1.0.11, < 3)
-      rubydora (>= 1.8.0, < 3)
-    active-triples (0.4.1)
-      activemodel (>= 3.0.0)
-      activesupport (>= 3.0.0)
-      deprecation (~> 0.1)
-      rdf (~> 1.1)
-      rdf-vocab (~> 0.8)
-    activemodel (5.2.5)
-      activesupport (= 5.2.5)
     activesupport (5.2.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -38,7 +21,6 @@ GEM
       nokogiri
     ast (2.4.2)
     awesome_print (1.9.2)
-    builder (3.2.4)
     bundler-audit (0.8.0)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
@@ -75,7 +57,6 @@ GEM
     config (2.2.3)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    daemons (1.3.1)
     deep_merge (1.2.1)
     deprecation (0.99.0)
       activesupport
@@ -88,23 +69,6 @@ GEM
     docile (1.3.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dor-rights-auth (1.7.0)
-      nokogiri
-    dor-services (9.6.2)
-      active-fedora (>= 8.7.0, < 9)
-      activesupport (~> 5.1)
-      deprecation (~> 0)
-      dor-rights-auth (~> 1.0, >= 1.2.0)
-      json (>= 1.8.1)
-      nokogiri (~> 1.6)
-      om (~> 3.0)
-      rdf (~> 1.1, >= 1.1.7)
-      rest-client (>= 1.7, < 3)
-      rsolr (>= 1.0.3, < 3)
-      rubydora (~> 2.1)
-      solrizer (~> 3.0)
-      stanford-mods (>= 2.3.1)
-      stanford-mods-normalizer (~> 0.1)
     dor-services-client (6.32.0)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.58.0)
@@ -167,13 +131,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
-    haml (5.2.1)
-      temple (>= 0.8.0)
-      tilt
     honeybadger (4.8.0)
-    hooks (0.4.1)
-      uber (~> 0.0.14)
-    htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -182,7 +140,6 @@ GEM
     ice_nine (0.11.2)
     iso-639 (0.3.5)
     json (2.5.1)
-    link_header (0.0.8)
     lockfile (2.1.3)
     lyber-core (6.1.1)
     method_source (1.0.0)
@@ -223,11 +180,6 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    om (3.2.0)
-      activemodel (>= 5.1, < 7)
-      activesupport
-      nokogiri (>= 1.4.2)
-      solrizer (~> 3.3)
     openapi3_parser (0.9.0)
       commonmarker (~> 0.17)
       psych (~> 3.1)
@@ -248,25 +200,6 @@ GEM
       rack
     rainbow (3.0.0)
     rake (13.0.3)
-    rdf (1.99.1)
-      link_header (~> 0.0, >= 0.0.8)
-    rdf-aggregate-repo (1.99.0)
-      rdf (~> 1.99)
-    rdf-rdfa (1.99.3)
-      haml (>= 4.0, < 6.0)
-      htmlentities (~> 4.3)
-      rdf (~> 1.99)
-      rdf-aggregate-repo (~> 1.1)
-      rdf-xsd (~> 1.1)
-    rdf-rdfxml (1.99.1)
-      htmlentities (~> 4.3)
-      rdf (~> 1.99)
-      rdf-rdfa (~> 1.99)
-      rdf-xsd (~> 1.99)
-    rdf-vocab (0.8.8)
-      rdf (~> 1.1, >= 1.1.10)
-    rdf-xsd (1.99.0)
-      rdf (~> 1.99)
     redis (4.2.5)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
@@ -286,9 +219,6 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rsolr (2.3.0)
-      builder (>= 2.1.2)
-      faraday (>= 0.9.0)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -317,15 +247,6 @@ GEM
       i18n
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
-    rubydora (2.1.0)
-      activemodel (>= 4.2.10)
-      activesupport
-      deprecation
-      equivalent-xml
-      hooks (~> 0.3)
-      mime-types
-      nokogiri
-      rest-client
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -337,28 +258,17 @@ GEM
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
     slop (4.8.2)
-    solrizer (3.4.1)
-      activesupport
-      daemons
-      nokogiri
-      stomp
-      xml-simple
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stanford-mods (2.6.3)
       activesupport
       mods (~> 2.2)
-    stanford-mods-normalizer (0.1.0)
-      nokogiri (~> 1.8)
-    stomp (1.4.10)
-    temple (0.8.2)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    uber (0.0.15)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
@@ -367,7 +277,6 @@ GEM
       rack (>= 1.0.0)
     whenever (1.0.0)
       chronic (>= 0.6.3)
-    xml-simple (1.1.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -381,7 +290,6 @@ DEPENDENCIES
   capistrano-yarn
   config (~> 2.0)
   dlss-capistrano (~> 3.11)
-  dor-services (~> 9.0)
   dor-services-client (~> 6.0)
   dor-workflow-client (~> 3.22)
   druid-tools
@@ -402,6 +310,7 @@ DEPENDENCIES
   rubocop
   simplecov (~> 0.17.1)
   slop
+  stanford-mods (~> 2.6)
   whenever
 
 BUNDLED WITH

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -45,7 +45,6 @@ rescue LoadError, NameError, NoMethodError
 end
 
 # Load core robot services
-require 'dor-services'
 require 'lyber_core'
 
 # Load any library files and all the robots
@@ -53,21 +52,7 @@ require 'lyber_core'
 Dir["#{ROBOT_ROOT}/lib/*/*.rb"].sort.each { |f| require f }
 require 'robots'
 
-Dor::Config.configure do
-  fedora do
-    url Settings.fedora.url
-  end
-
-  ssl do
-    cert_file Settings.ssl.cert_file
-    key_file Settings.ssl.key_file
-    key_pass Settings.ssl.key_pass
-  end
-
-  solr.url Settings.solr.url
-end
-
-REDIS_URL ||= Settings.redis.url
+REDIS_URL ||= Settings.redis.url # rubocop:disable Lint/OrAssignmentToConstant
 
 module Was
   def self.connect_dor_services_app

--- a/spec/was_crawl_dissemination/utilities_spec.rb
+++ b/spec/was_crawl_dissemination/utilities_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe Dor::WASCrawl::Dissemination::Utilities do
   end
 
   context '.get_collection_id' do
-    let(:druid_obj) { double(Dor::Item) }
+    let(:druid_obj) { double(Cocina::Models::DRO) }
+
     it 'delegates to Dor::WASCrawl::Utilities' do
       expect(Dor::WASCrawl::Utilities).to receive(:get_collection_id).with(druid_obj).and_return('abc')
       expect(described_class.get_collection_id(druid_obj)).to eq 'abc'

--- a/spec/was_crawl_preassembly/lib/desc_metadata_generator_service_spec.rb
+++ b/spec/was_crawl_preassembly/lib/desc_metadata_generator_service_spec.rb
@@ -28,9 +28,6 @@ describe Dor::WASCrawl::DescMetadataGenerator do
     end
   end
 
-  context Dor::WASCrawl::DescMetadataGenerator, 'generate_xml_doc' do
-  end
-
   def generate_object(druid_id)
     Dor::WASCrawl::DescMetadataGenerator.new(@collection_id,
                                              @staging_path.to_s, druid_id)


### PR DESCRIPTION
**HOLD** until tested in staging env

## Why was this change made?

Stay up to date and jettison unused dependencies

## How was this change tested?

CI, to be tested by @andrewjbtw in staging env

## Which documentation and/or configurations were updated?

None

