### PR TITLE
use the start accession endpoint to deal with all versioning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,3 +102,11 @@ Style/StringChars: # (new in 1.12)
   Enabled: true
 Style/SwapValues: # (new in 1.1)
   Enabled: true
+Lint/EmptyInPattern: # (new in 1.16)
+  Enabled: true
+Style/InPatternThen: # (new in 1.16)
+  Enabled: true
+Style/MultilineInPatternThen: # (new in 1.16)
+  Enabled: true
+Style/QuotedSymbols: # (new in 1.16)
+  Enabled: true

--- a/robots/was_seed_preassembly/end_was_seed_preassembly.rb
+++ b/robots/was_seed_preassembly/end_was_seed_preassembly.rb
@@ -8,25 +8,11 @@ module Robots
 
         def perform(druid)
           object_client = Dor::Services::Client.object(druid)
-          version_client = object_client.version
-          current_version = version_client.current
-
-          start_completed = workflow_service.workflow_status('dor', druid, 'accessionWF', 'start-accession')
-          end_completed = workflow_service.workflow_status('dor', druid, 'accessionWF', 'end-accession')
-
-          if start_completed.nil? && end_completed.nil?
-            # This object isn't accessioned yet.
-            workflow_service.create_workflow_by_name(druid, 'accessionWF', version: current_version)
-          elsif start_completed.eql?('completed') && end_completed.eql?('completed')
-            # We need to open a new version
-            version_client.open
-            version_client.close(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')
-          elsif start_completed.eql?('completed') && !end_completed.eql?('completed')
-            # The object is still in accessioning, we have to wait until finish
-            fail "Druid object #{druid} is still in accessioning, reset the end-was-seed-preassembly after accessioning completion"
-          else
-            fail "Druid object #{druid} is unknown status"
-          end
+          object_client.accession.start(
+            workflow: 'accessionWF',
+            significance: 'major',
+            description: 'wasSeedPreassembly'
+          )
         end
       end
     end

--- a/spec/was_seed_preassembly/robots/end_was_seed_preassembly_spec.rb
+++ b/spec/was_seed_preassembly/robots/end_was_seed_preassembly_spec.rb
@@ -4,57 +4,33 @@ RSpec.describe Robots::DorRepo::WasSeedPreassembly::EndWasSeedPreassembly do
   describe 'perform' do
     let(:druid) { 'druid:ab123cd4567' }
     let(:instance) { described_class.new }
-    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+    let(:accession_object) { instance_double(Dor::Services::Client::Accession, start: true) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, accession: accession_object) }
 
     subject(:perform) { instance.perform(druid) }
 
     before do
-      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
-      allow(WorkflowClientFactory).to receive(:build).and_return(wf_client)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     end
 
     context 'for new objects' do
-      let(:wf_client) { instance_double(Dor::Workflow::Client, workflow_status: nil) }
-
-      it 'initializes accessionWF' do
-        allow(instance.workflow_service).to receive(:create_workflow_by_name)
+      it 'starts accessioning' do
         perform
-        expect(instance.workflow_service).to have_received(:create_workflow_by_name).with(druid, 'accessionWF', version: '1')
+        expect(object_client.accession).to have_received(:start).with(
+          workflow: 'accessionWF',
+          significance: 'major',
+          description: 'wasSeedPreassembly'
+        )
       end
     end
 
-    context 'for already accessioned objects' do
-      let(:wf_client) { instance_double(Dor::Workflow::Client, workflow_status: 'completed') }
-
-      it 're-versions the object' do
-        expect(version_client).to receive(:open)
-        expect(version_client).to receive(:close).with(description: 'Updating the seed object through wasSeedPreassemblyWF', significance: 'Major')
-        perform
-      end
-    end
-
-    context 'for the objects that are under accessioning' do
-      let(:wf_client) { instance_double(Dor::Workflow::Client) }
+    context 'for objects where the start accession call fails' do
       before do
-        allow(wf_client).to receive(:workflow_status).with('dor', 'druid:ab123cd4567', 'accessionWF', 'start-accession').and_return('completed')
-        allow(wf_client).to receive(:workflow_status).with('dor', 'druid:ab123cd4567', 'accessionWF', 'end-accession').and_return(nil)
+        allow(object_client).to receive(:accession).and_raise(StandardError)
       end
 
       it 'issues an error' do
-        expect { perform }.to raise_error('Druid object druid:ab123cd4567 is still in accessioning, reset the end-was-seed-preassembly after accessioning completion')
-      end
-    end
-
-    context 'for the objects with unknown status' do
-      let(:wf_client) { instance_double(Dor::Workflow::Client) }
-      before do
-        allow(wf_client).to receive(:workflow_status).with('dor', 'druid:ab123cd4567', 'accessionWF', 'start-accession').and_return(nil)
-        allow(wf_client).to receive(:workflow_status).with('dor', 'druid:ab123cd4567', 'accessionWF', 'end-accession').and_return('completed')
-      end
-
-      it 'issues an error' do
-        expect { perform }.to raise_error('Druid object druid:ab123cd4567 is unknown status')
+        expect { perform }.to raise_error(StandardError)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #317 ... instead of trying to do the version logic and versioning in this code, we can use the endpoint in dor-services-app that was designed for this purpose.  We already use this endpoint from pre-assembly, goobi, and sdr-api (and maybe other spots) for the same reasons.

dor-services-app method: https://github.com/sul-dlss/dor-services-app/blob/main/app/controllers/objects_controller.rb#L73-L104

dor-services-client class that calls this: https://github.com/sul-dlss/dor-services-client/blob/main/lib/dor/services/client/accession.rb

pre-assembly use:
https://github.com/sul-dlss/pre-assembly/blob/main/app/lib/pre_assembly/digital_object.rb#L76
https://github.com/sul-dlss/pre-assembly/blob/main/app/services/start_accession.rb

sdr-api use: 
https://github.com/sul-dlss/sdr-api/blob/main/app/jobs/update_job.rb#L44-L49

## How was this change tested?

Updated spec
Should also deploy to stage and verify


## Which documentation and/or configurations were updated?



