### PR TITLE
Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,14 @@
 version: 2.1
 
+parameters:
+  ruby-version:
+    type: string
+    default: "3.0.3"
+
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.7.1
+      - image: 'cimg/ruby:<< pipeline.parameters.ruby-version >>-node'
         environment:
           CC_TEST_REPORTER_ID: 83c16289b10e9312a748431ec6adbb1c24767afbf317bb05691f2f54acc13cf1
           RAILS_ENV: test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,3 +110,38 @@ Style/MultilineInPatternThen: # (new in 1.16)
   Enabled: true
 Style/QuotedSymbols: # (new in 1.16)
   Enabled: true
+
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+Naming/BlockForwarding: # new in 1.24
+  Enabled: true
+Security/IoMethods: # new in 1.22
+  Enabled: true
+Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileWrite: # new in 1.24
+  Enabled: true
+Style/MapToHash: # new in 1.24
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'lockfile'       # file locks needed for mutual exclusion during rollup and 
 gem 'mini_exiftool'  # was-seed-preassembly thumbnail creation
 gem 'mini_magick'    # was-seed-preassembly thumbnail creation
 gem 'assembly-image' # was-seed-preassembly thumbnail creation
-gem 'rest-client'    # was-seed-dissemination to call was-thumbnail-service
 gem 'pry'            # for bin/console
 gem 'slop'           # for bin/run_robot
 gem 'honeybadger'

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,6 @@ end
 
 group :deployment do
   gem 'capistrano-bundler'
-  gem 'capistrano-yarn'
+  gem 'capistrano-yarn' # for generating was-seed-preassembly thumbnail with chrome (PR #242)
   gem 'dlss-capistrano', '~> 3.11'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@ source 'https://rubygems.org'
 
 gem 'config', '~> 2.0'
 gem 'druid-tools'
-gem 'dor-services-client', '~> 7.0'
-gem 'dor-workflow-client', '~> 3.22'
-gem 'faraday', '~> 0.15.0'
+gem 'dor-services-client', '~> 7.0', git: 'https://github.com/sul-dlss/dor-services-client.git', branch: 'faraday2'
+gem 'dor-workflow-client', '~> 3.22', git: 'https://github.com/sul-dlss/dor-workflow-client.git', branch: 'faraday2'
 gem 'lyber-core', '~> 6.0'
 gem 'stanford-mods', '~> 2.6'
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,7 @@ group :development, :test do
   gem 'equivalent-xml'
   gem 'awesome_print'
   gem 'rubocop'
-  # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
-  gem 'simplecov', '~> 0.17.1', require: false
+  gem 'simplecov'
   gem 'pry-byebug'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     assembly-image (1.7.7)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
-    assembly-objectfile (1.10.3)
+    assembly-objectfile (1.11.0)
       activesupport (>= 5.2.0)
       deprecation
       dry-struct (~> 1.0)
@@ -69,7 +69,7 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services-client (7.4.0)
+    dor-services-client (7.5.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.62.0)
       deprecation
@@ -170,7 +170,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    openapi3_parser (0.9.0)
+    openapi3_parser (0.9.1)
       commonmarker (~> 0.17)
       psych (~> 3.1)
     openapi_parser (0.15.0)
@@ -252,7 +252,7 @@ GEM
     stanford-mods (2.6.3)
       activesupport
       mods (~> 2.2)
-    thor (1.1.0)
+    thor (1.2.1)
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -264,7 +264,7 @@ GEM
       rack (>= 1.0.0)
     whenever (1.0.0)
       chronic (>= 0.6.3)
-    zeitwerk (2.5.1)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby
@@ -301,4 +301,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.27
+   2.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,37 @@
+GIT
+  remote: https://github.com/sul-dlss/dor-services-client.git
+  revision: c8d8c8fd133d30d6b9162261ce828a550f148add
+  branch: faraday2
+  specs:
+    dor-services-client (7.5.0)
+      activesupport (>= 4.2, < 8)
+      cocina-models (~> 0.62.0)
+      deprecation
+      faraday (~> 2.0)
+      faraday-retry
+      zeitwerk (~> 2.1)
+
+GIT
+  remote: https://github.com/sul-dlss/dor-workflow-client.git
+  revision: 1a28ea2c171f3ac5d566c048e0b8c23221b21839
+  branch: faraday2
+  specs:
+    dor-workflow-client (3.24.0)
+      activesupport (>= 3.2.1, < 8)
+      deprecation (>= 0.99.0)
+      faraday (~> 2.0)
+      faraday-retry
+      nokogiri (~> 1.6)
+      zeitwerk (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.4)
+    activesupport (7.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     assembly-image (1.7.7)
@@ -60,7 +85,7 @@ GEM
     deep_merge (1.2.1)
     deprecation (1.1.0)
       activesupport
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     dlss-capistrano (3.11.1)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
@@ -69,19 +94,6 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services-client (7.5.0)
-      activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.62.0)
-      deprecation
-      faraday (>= 0.15, < 2)
-      zeitwerk (~> 2.1)
-    dor-workflow-client (3.24.0)
-      activesupport (>= 3.2.1, < 8)
-      deprecation (>= 0.99.0)
-      faraday (>= 0.9.2, < 2.0)
-      faraday_middleware
-      nokogiri (~> 1.6)
-      zeitwerk (~> 2.1)
     druid-tools (2.1.0)
       deprecation
     dry-configurable (0.13.0)
@@ -120,14 +132,16 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
-    edtf (3.0.6)
-      activesupport (>= 3.0, < 7.0)
+    edtf (3.0.7)
+      activesupport (>= 3.0, < 8.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.14.0)
-      faraday (>= 0.7.4, < 1.0)
+    faraday (2.0.1)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.1)
+    faraday-retry (1.0.1)
+      faraday (~> 2.0)
     honeybadger (4.9.0)
     http-accept (1.7.0)
     http-cookie (1.0.4)
@@ -142,7 +156,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.1115)
+    mime-types-data (3.2022.0105)
     mini_exiftool (2.10.2)
     mini_magick (4.11.0)
     mini_portile2 (2.6.1)
@@ -154,7 +168,6 @@ GEM
       nom-xml (~> 1.0)
     mono_logger (1.1.1)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     net-scp (3.0.0)
@@ -175,7 +188,7 @@ GEM
       psych (~> 3.1)
     openapi_parser (0.15.0)
     parallel (1.21.0)
-    parser (3.0.3.2)
+    parser (3.1.0.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -222,16 +235,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
-    rubocop (1.23.0)
+    rubocop (1.24.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.12.0, < 2.0)
+      rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.0)
+    rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -277,11 +290,10 @@ DEPENDENCIES
   capistrano-yarn
   config (~> 2.0)
   dlss-capistrano (~> 3.11)
-  dor-services-client (~> 7.0)
-  dor-workflow-client (~> 3.22)
+  dor-services-client (~> 7.0)!
+  dor-workflow-client (~> 3.22)!
   druid-tools
   equivalent-xml
-  faraday (~> 0.15.0)
   honeybadger
   lockfile
   lyber-core (~> 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,8 +92,6 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
     druid-tools (2.1.0)
       deprecation
     dry-configurable (0.13.0)
@@ -143,14 +141,10 @@ GEM
     faraday-retry (1.0.1)
       faraday (~> 2.0)
     honeybadger (4.9.0)
-    http-accept (1.7.0)
-    http-cookie (1.0.4)
-      domain_name (~> 0.5)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iso-639 (0.3.5)
-    json (2.6.1)
     lockfile (2.1.3)
     lyber-core (6.1.1)
     method_source (1.0.0)
@@ -173,7 +167,6 @@ GEM
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
-    netrc (0.11.0)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
@@ -216,11 +209,6 @@ GEM
     resque-pool (0.7.1)
       rake (>= 10.0, < 14.0)
       resque (>= 1.22, < 3)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -248,11 +236,12 @@ GEM
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -269,9 +258,6 @@ GEM
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -304,10 +290,9 @@ DEPENDENCIES
   rake
   resque
   resque-pool
-  rest-client
   rspec
   rubocop
-  simplecov (~> 0.17.1)
+  simplecov
   slop
   stanford-mods (~> 2.6)
   whenever

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,9 +1,9 @@
 # Ensure subsequent requires search the correct local paths
-$LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'robots'))
+$LOAD_PATH.unshift File.expand_path(File.join(__dir__, '..', 'lib'))
+$LOAD_PATH.unshift File.expand_path(File.join(__dir__, '..', 'robots'))
 
 require 'rubygems'
-require 'bundler/setup'
+require 'bundler/setup' # Set up gems listed in the Gemfile.
 Bundler.require(:default)
 require 'logger'
 require 'workflow_client_factory'
@@ -14,6 +14,7 @@ ROBOT_ROOT = File.expand_path("#{File.dirname(__FILE__)}/..")
 ROBOT_LOG = Logger.new(File.join(ROBOT_ROOT, "log/#{environment}.log"))
 ROBOT_LOG.level = Logger::SEV_LABEL.index(ENV['ROBOT_LOG_LEVEL']) || Logger::INFO
 
+# config gem, without Rails, requires we load the config ourselves
 require 'config'
 Config.setup do |config|
   # Name of the constant exposing loaded settings

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,9 @@ ENV['ROBOT_ENVIRONMENT'] = 'test'
 require 'simplecov'
 SimpleCov.start
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 
-require File.expand_path("#{File.dirname(__FILE__)}/../config/boot")
+require File.expand_path(File.join(__dir__, '..', 'config', 'boot'))
 
 require 'rspec'
 require 'awesome_print'

--- a/spec/was_crawl_dissemination/cdx_generator_service_spec.rb
+++ b/spec/was_crawl_dissemination/cdx_generator_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Dor::WASCrawl::CDXGeneratorService do
     let(:warc_file_list) { Dor::WASCrawl::Dissemination::Utilities.warc_file_list(contentMetadata) }
 
     context "when contentMetadata has arcs or warcs" do
-      let(:contentMetadata) { File.open("#{@content_metadata_xml_location}contentMetadata_3files.xml").read }
+      let(:contentMetadata) { File.read("#{@content_metadata_xml_location}contentMetadata_3files.xml") }
 
       it 'generates cdx files for each warc or arc file in contentMetadata', :openwayback_prerequisite do
         cdx_generator = Dor::WASCrawl::CDXGeneratorService.new(@collection_path, @druid_id_1, warc_file_list)
@@ -73,7 +73,7 @@ RSpec.describe Dor::WASCrawl::CDXGeneratorService do
     end
 
     context "when contentMetadata has no arcs or warcs" do
-      let(:contentMetadata) { File.open("#{@content_metadata_xml_location}contentMetadata_0file.xml").read }
+      let(:contentMetadata) { File.read("#{@content_metadata_xml_location}contentMetadata_0file.xml") }
 
       it 'should do nothing for the contentMetadata without any arcs or warcs', :openwayback_prerequisite do
         cdx_generator = Dor::WASCrawl::CDXGeneratorService.new(@collection_path, @druid_id_3, warc_file_list)


### PR DESCRIPTION
Waiting for dor-services-client and dor-workflow-client to be released using Faraday 2.

## Why was this change made?

To get CI to run on Ruby 3.0

Also
- remove unused gems
- remove unnec. gem version declarations in Gemfile
- use better path constructs

## How was this change tested?

circleci

## Which documentation and/or configurations were updated?



