### PR TITLE
Removes stacks attribute.

### DIFF
--- a/spec/was_crawl_preassembly/lib/content_metadata_generator_service_spec.rb
+++ b/spec/was_crawl_preassembly/lib/content_metadata_generator_service_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Dor::WASCrawl::ContentMetadataGenerator do
   def generate_data_items
     @expected_content_metadata = <<~EOF
       <?xml version="1.0"?>
-      <contentMetadata type="file" stacks="/web-archiving-stacks/data/collections/" id="druid:gh123gh1234">
+      <contentMetadata type="file" id="druid:gh123gh1234">
         <resource type="file" id="gh123gh1234_1">
           <file dataType="WARC" publish="no" shelve="yes" preserve="yes" id="WARC-Test.warc.gz" size="6608320" mimetype="application/octet-stream">
             <checksum type="MD5">c7edbde066e4697b3f2d823ac42c3692</checksum>

--- a/template/wasCrawlPreassembly/contentMetadata_dark.xslt
+++ b/template/wasCrawlPreassembly/contentMetadata_dark.xslt
@@ -4,9 +4,6 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:template match="/crawlObject">
 
 <contentMetadata type="file" >
-     <xsl:attribute name="stacks">
-        <xsl:value-of select="concat('/web-archiving-stacks/data/collections/',collectionId)"/>
-     </xsl:attribute>
      
     <xsl:for-each select="files/file[type='WARC']">
 		<resource type="file" >
@@ -43,7 +40,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 			</file>
 		</resource>
     </xsl:for-each>
-	
+
 
 </contentMetadata>
 

--- a/template/wasCrawlPreassembly/contentMetadata_public.xslt
+++ b/template/wasCrawlPreassembly/contentMetadata_public.xslt
@@ -4,9 +4,6 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:template match="/crawlObject">
 
 <contentMetadata type="file" >
-     <xsl:attribute name="stacks">
-        <xsl:value-of select="concat('/web-archiving-stacks/data/collections/',collectionId)"/>
-     </xsl:attribute>
      
     <xsl:for-each select="files/file[type='WARC']">
 		<resource type="file" >
@@ -43,7 +40,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 			</file>
 		</resource>
     </xsl:for-each>
-	
+
 
 </contentMetadata>
 


### PR DESCRIPTION
closes #376

## Why was this change made?
This attribute is no longer used.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



