### PR TITLE
Stage deploys should use the production environment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,8 +33,10 @@ set :linked_dirs, %w(log config/environments config/certs config/settings jar tm
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
-set :stages, %w(dev stage prod)
-set :default_stage, 'dev'
+set :deploy_environment, 'production'
+set :whenever_environment, fetch(:deploy_environment)
+set :default_env, { robot_environment: fetch(:deploy_environment) }
+set :bundle_without, %w{deployment development test}.join(' ')
 
 namespace :deploy do
   desc 'Download WAS Metadata Extractor for was-crawl-preassembly'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,8 +1,3 @@
 server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db monitor rollup}
 
 Capistrano::OneTimeKey.generate_one_time_key!
-
-set :deploy_environment, 'production'
-set :whenever_environment, fetch(:deploy_environment)
-set :default_env, { robot_environment: fetch(:deploy_environment) }
-set :bundle_without, %w{deployment development test}.join(' ')

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,8 +1,3 @@
 server 'was-robots1-qa.stanford.edu', user: 'was', roles: %w{web app db rollup}
 
 Capistrano::OneTimeKey.generate_one_time_key!
-
-set :deploy_environment, 'production'
-set :whenever_environment, fetch(:deploy_environment)
-set :default_env, { robot_environment: fetch(:deploy_environment) }
-set :bundle_without, %w{deployment test}.join(' ')

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,8 +1,3 @@
 server 'was-robots1-stage.stanford.edu', user: 'was', roles: %w{web app db rollup}
 
 Capistrano::OneTimeKey.generate_one_time_key!
-
-set :deploy_environment, 'test'
-set :whenever_environment, fetch(:deploy_environment)
-set :default_env, { robot_environment: fetch(:deploy_environment) }
-set :bundle_without, %w{deployment test}.join(' ')


### PR DESCRIPTION
Just like QA and production. This is a remnant of how we used to have diff Rails envs (and robot envs) in diff deployment envs, which we now believe to be an anti-pattern.

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


