### PR TITLE
Removes WASMetadataExtractor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ to start all robots defined in `config/environments/robots_ENV.yml`.
 
 The WAS robots depend on some java projects:
 
-- [WasMetadataExtractor](https://github.com/sul-dlss/WASMetadataExtractor)
-  - to extract metadata from web archiving ARC and WARC files, used by wasCrawlPreassemblyWF.
 - [openwayback](https://github.com/sul-dlss/openwayback)
   - to index WARC materials for the Stanford Web Archiving Portal, used by cdx-generator step in wasCrawlDisseminationWF
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,13 +39,6 @@ set :default_env, { robot_environment: fetch(:deploy_environment) }
 set :bundle_without, %w{deployment development test}.join(' ')
 
 namespace :deploy do
-  desc 'Download WAS Metadata Extractor for was-crawl-preassembly'
-  task :download_metadata_extractor_tar do
-    on roles(:app), in: :sequence, wait: 10 do
-      execute :curl, '-s https://sul-ci-prod.stanford.edu/artifacts/WASMetadataExtractor-0.0.3-SNAPSHOT-jar-with-dependencies.jar', "> #{fetch(:deploy_to)}/shared/jar/WASMetadataExtractor.jar"
-    end
-  end
-
   desc 'Download/unpack OpenWayback tar file to work with was-crawl-diss indexer script.'
   task :download_openwayback_tar do
     on roles(:app), in: :sequence, wait: 10 do
@@ -56,7 +49,6 @@ namespace :deploy do
   end
 
   # Download and extract JARs before restarting
-  after :publishing, :download_metadata_extractor_tar
   after :publishing, :download_openwayback_tar
 end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,7 +17,6 @@ was_crawl:
   source_path: '/was_unaccessioned_data/jobs/' # the root for the storage for the input directory
   staging_path: '/dor/workspace/'  # the root for the storage for DRUID tree that will be the input to AssemblyWF
   extracted_metadata_xml_location: 'tmp'
-  metadata_extractor_jar: 'jar/WASMetadataExtractor.jar'
   java_heap_size: '-Xmx2048m'
   dedicated_lane: 'default'
 

--- a/robots/was_crawl_preassembly/metadata_extractor.rb
+++ b/robots/was_crawl_preassembly/metadata_extractor.rb
@@ -17,7 +17,7 @@ module Robots
 
           LyberCore::Log.info "Creating MetadataExtractor with parameters #{collection_id}, #{crawl_id}, #{staging_path}, #{druid}"
           metadata_extractor_service = Dor::WASCrawl::MetadataExtractor.new(collection_id, crawl_id, staging_path.to_s, druid)
-          metadata_extractor_service.run_metadata_extractor_jar
+          metadata_extractor_service.run
         end
       end
     end

--- a/spec/was_crawl_preassembly/lib/metadata_extractor_service_spec.rb
+++ b/spec/was_crawl_preassembly/lib/metadata_extractor_service_spec.rb
@@ -2,63 +2,32 @@ require 'spec_helper'
 require 'was_crawl_preassembly/metadata_extractor_service'
 
 describe Dor::WASCrawl::MetadataExtractor do
-  before(:all) do
-    @staging_path = Pathname(File.dirname(__FILE__)).join('../fixtures/workspace')
-    @collection_id = 'test_collection'
-    @crawl_id = 'test_crawl'
+  let(:extractor) { described_class.new('test_collection', 'test_crawl', staging_path, 'druid:ab123ab1234') }
+  let(:staging_path) { Pathname(File.dirname(__FILE__)).join('../fixtures/workspace') }
+
+  before do
+    allow(File).to receive(:write)
   end
 
-  context described_class, '.call_java_library with druid that has one warc file' do
-    it 'calls out to java CLI for .run_metadata_extractor_jar' do
-      druid_id = 'druid:ab123ab1234'
-      metadata_extractor_service = described_class.new(@collection_id, @crawl_id, @staging_path.to_s, druid_id)
-      expected_cmd_string = %r{java .*-jar jar/WASMetadataExtractor.jar -f XML .*/ab123ab1234/content -o tmp/druid:ab123ab1234.xml -c config/extractor.yml --collectionId #{@collection_id} --crawlId #{@crawl_id}}
-      expect(metadata_extractor_service).to receive(:system).with(expected_cmd_string).and_return(true) # leave WASMetadataExtractor testing to its repo
-      metadata_extractor_service.run_metadata_extractor_jar
-    end
-  end
-
-  context described_class, '.prepare_parameters' do
-    it 'should run successfully with existent druid' do
-      druid_id = 'druid:ab123ab1234'
-      metadata_extractor_service = described_class.new(@collection_id, @crawl_id, @staging_path.to_s, druid_id)
-      metadata_extractor_service.prepare_parameters
-      expect(metadata_extractor_service.instance_variable_get(:@input_directory)).to eq "#{@staging_path}/ab/123/ab/1234/ab123ab1234/content"
-      expect(metadata_extractor_service.instance_variable_get(:@xml_output_location)).to eq 'tmp/druid:ab123ab1234.xml'
-    end
-
-    it 'should raise an error wrong druid' do
-      druid_id = 'druid:xx999xxx9999'
-      metadata_extractor_service = described_class.new(@collection_id, @crawl_id, @staging_path.to_s, druid_id)
-      expect { metadata_extractor_service.prepare_parameters }.to raise_error(ArgumentError, /Invalid DRUID/)
-    end
-
-    it 'should raise an error with nil druid' do
-      druid_id = nil
-      metadata_extractor_service = described_class.new(@collection_id, @crawl_id, @staging_path.to_s, druid_id)
-      expect { metadata_extractor_service.prepare_parameters }.to raise_error(ArgumentError, /Invalid DRUID/)
-    end
-
-    it 'should raise an error with existent druid tree without content folder' do
-      druid_id = 'druid:ef123ef1234'
-      metadata_extractor_service = described_class.new(@collection_id, @crawl_id, @staging_path.to_s, druid_id)
-      expect { metadata_extractor_service.prepare_parameters }.to raise_error(RuntimeError, /content doesn't exist/)
-    end
-  end
-
-  context described_class, '.build_cmd_string' do
-    it 'should build the command string as expected' do
-      druid_id = 'druid:ab123ab1234'
-      expected_cmd_string = 'java -Xmx2048m -jar jar_path -f XML -d input_directory -o tmp/druid:ab123ab1234.xml -c config/extractor.yml --collectionId test_collection --crawlId test_crawl 2>> log_file'
-
-      metadata_extractor_service = described_class.new(@collection_id, @crawl_id, @staging_path.to_s, druid_id)
-      metadata_extractor_service.instance_variable_set(:@jar_path, 'jar_path')
-      metadata_extractor_service.instance_variable_set(:@input_directory, 'input_directory')
-      metadata_extractor_service.instance_variable_set(:@java_log_file, 'log_file')
-      metadata_extractor_service.instance_variable_set(:@xml_output_location, 'tmp/druid:ab123ab1234.xml')
-
-      actual_cmd_string = metadata_extractor_service.build_cmd_string
-      expect(actual_cmd_string).to eq expected_cmd_string
-    end
+  it 'generates XML file' do
+    extractor.run
+    expect(File).to have_received(:write).with('tmp/druid:ab123ab1234.xml', <<~XML
+      <?xml version="1.0"?>
+      <crawlObject>
+        <crawlId>test_crawl</crawlId>
+        <collectionId>test_collection</collectionId>
+        <files>
+          <file>
+            <name>WARC-Test.warc.gz</name>
+            <type>WARC</type>
+            <size>6608320</size>
+            <mimeType>application/warc</mimeType>
+            <checksumMD5>c7edbde066e4697b3f2d823ac42c3692</checksumMD5>
+            <checksumSHA1>3a9f2ffac1497c70291d93a8bc86c1469547d8f8</checksumSHA1>
+          </file>
+        </files>
+      </crawlObject>
+    XML
+    )
   end
 end


### PR DESCRIPTION
closes #212

## Why was this change made? 🤔
This will allow unsticking some WARCs that are stuck on this workflow step, which will allow the elimination of the workflow step.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

stage
