### PR TITLE
Avoid 'should' in spec descriptions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -85,15 +85,6 @@ RSpec/ContextWording:
 RSpec/ExampleLength:
   Max: 17
 
-# Offense count: 23
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: CustomTransform, IgnoredWords.
-RSpec/ExampleWording:
-  Exclude:
-    - 'spec/lib/dor/was_crawl/cdx_generator_service_spec.rb'
-    - 'spec/lib/dor/was_crawl/dissemination/utilities_spec.rb'
-    - 'spec/lib/dor/was_seed/content_metadata_generator_service_spec.rb'
-
 # Offense count: 145
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:

--- a/spec/lib/dor/was_crawl/cdx_generator_service_spec.rb
+++ b/spec/lib/dor/was_crawl/cdx_generator_service_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
     context "when contentMetadata has no arcs or warcs" do
       let(:contentMetadata) { File.read("#{@content_metadata_xml_location}contentMetadata_0file.xml") }
 
-      it 'should do nothing for the contentMetadata without any arcs or warcs', :openwayback_prerequisite do
+      it 'does nothing for the contentMetadata without any arcs or warcs', :openwayback_prerequisite do
         cdx_generator = described_class.new(@collection_path, @druid_id_3, warc_file_list)
         cdx_generator.instance_variable_set(:@cdx_working_directory, "#{@stacks_path}/data/indices/cdx_working")
         cdx_generator.generate_cdx_for_crawl
@@ -104,7 +104,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       FileUtils.rm 'tmp/ARC-Test.cdx'
     end
 
-    it 'should generate CDX file for the input warc file', :openwayback_prerequisite do
+    it 'generates CDX file for the input warc file', :openwayback_prerequisite do
       cdx_file_path = 'tmp/WARC-Test.cdx'
       warc_file_path = "#{@workspace}/aa111aa1111/WARC-Test.warc.gz"
       @cdx_generator.generate_cdx_for_one_warc(warc_file_path, cdx_file_path)
@@ -116,7 +116,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       expect(actual_cdx_MD5).to eq(expected_cdx_MD5)
     end
 
-    it 'should generate CDX file for the input arc file', :openwayback_prerequisite do
+    it 'generates CDX file for the input arc file', :openwayback_prerequisite do
       cdx_file_path = 'tmp/ARC-Test.cdx'
       warc_file_path = "#{@workspace}/cc111cc1111/ARC-Test.arc.gz"
       @cdx_generator.generate_cdx_for_one_warc(warc_file_path, cdx_file_path)
@@ -134,37 +134,37 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       @cdx_generator = described_class.new('', '', [])
     end
 
-    it 'should return the cdx file for .warc.gz' do
+    it 'returns the cdx file for .warc.gz' do
       warc_file_name = 'file.warc.gz'
       cdx_file_name = @cdx_generator.get_cdx_file_name(warc_file_name)
       expect(cdx_file_name).to eq('file.cdx')
     end
 
-    it 'should return the cdx file for .arc.gz' do
+    it 'returns the cdx file for .arc.gz' do
       warc_file_name = 'file.arc.gz'
       cdx_file_name = @cdx_generator.get_cdx_file_name(warc_file_name)
       expect(cdx_file_name).to eq('file.cdx')
     end
 
-    it 'should return the cdx file for .warc' do
+    it 'returns the cdx file for .warc' do
       warc_file_name = 'file.warc'
       cdx_file_name = @cdx_generator.get_cdx_file_name(warc_file_name)
       expect(cdx_file_name).to eq('file.cdx')
     end
 
-    it 'should return the cdx file for .arc' do
+    it 'returns the cdx file for .arc' do
       warc_file_name = 'file.arc'
       cdx_file_name = @cdx_generator.get_cdx_file_name(warc_file_name)
       expect(cdx_file_name).to eq('file.cdx')
     end
 
-    it 'should return the cdx file for irregular file extension' do
+    it 'returns the cdx file for irregular file extension' do
       warc_file_name = 'file.txt'
       cdx_file_name = @cdx_generator.get_cdx_file_name(warc_file_name)
       expect(cdx_file_name).to eq('file.txt.cdx')
     end
 
-    it 'should return the cdx file without the directory path' do
+    it 'returns the cdx file without the directory path' do
       expect(@cdx_generator.get_cdx_file_name('tmp/file.txt')).to eq('file.txt.cdx')
       expect(@cdx_generator.get_cdx_file_name('./file.txt')).to eq('file.txt.cdx')
       expect(@cdx_generator.get_cdx_file_name('../file.txt')).to eq('file.txt.cdx')
@@ -179,7 +179,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       @cdx_generator = described_class.new('', '', [])
     end
 
-    it 'should returns the command string as expected' do
+    it 'returns the command string as expected' do
       warc_file_name = 'file.warc'
       cdx_file_name  = 'file.cdx'
       @cdx_generator.instance_variable_set(:@cdx_working_directory, 'working_directory/')
@@ -187,7 +187,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       expect(cmd_string).to eq('jar/openwayback/bin/cdx-indexer file.warc file.cdx 2>> log/cdx_indexer.log')
     end
 
-    it 'should raise an error with nil or missing file names' do
+    it 'raises an error with nil or missing file names' do
       warc_file_name = nil
       cdx_file_name = 'file.cdx'
 
@@ -199,7 +199,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
   end
 
   context Dor::WasCrawl::Dissemination::Utilities, '.run_sys_cmd', :openwayback_prerequisite do
-    it 'should generate CDX file in the right location with valid WARC file' do
+    it 'generates CDX file in the right location with valid WARC file' do
       warc_file_name = "#{@workspace}/aa111aa1111/WARC-Test.warc.gz"
       cdx_file_name = 'tmp/WARC-Test.cdx'
       cmd_string = "jar/openwayback/bin/cdx-indexer  #{warc_file_name} #{cdx_file_name} 2>> log/cdx_indexer.log"
@@ -212,7 +212,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       expect(actual_cdx_MD5).to eq(expected_cdx_MD5)
     end
 
-    it 'should raise an error with invalid input file' do
+    it 'raises an error with invalid input file' do
       warc_file_name = '{@workspace}/bb111bbb1111/WARC-Test.txt'
       cdx_file_name = 'tmp/WARC-Test.cdx'
       cmd_string = "jar/openwayback/bin/cdx-indexer  #{warc_file_name} #{cdx_file_name} 2>> log/cdx_indexer.log"

--- a/spec/lib/dor/was_crawl/dissemination/utilities_spec.rb
+++ b/spec/lib/dor/was_crawl/dissemination/utilities_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 RSpec.describe Dor::WasCrawl::Dissemination::Utilities do
   describe '.run_sys_cmd' do
-    it 'should return nothing with succesful command' do
+    it 'returns nothing with succesful command' do
       described_class.run_sys_cmd('ls', '')
     end
 
-    it 'should raise an error with wrong command' do
+    it 'raises an error with wrong command' do
       expect { described_class.run_sys_cmd('lss', '') }.to raise_error StandardError
     end
   end

--- a/spec/lib/dor/was_seed/content_metadata_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/content_metadata_generator_service_spec.rb
@@ -46,25 +46,25 @@ RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
   end
 
   describe '.generate_xml_doc' do
-    it 'should return a complete xml element for valid druid and an image xml element' do
+    it 'returns a complete xml element for valid druid and an image xml element' do
       actual_xml_element = cm_generator_instance_with_druid.generate_xml_doc @expected_thumbnal_xml_element
       expect(actual_xml_element.to_xml).to eq(@expected_full_xml_element.to_xml)
       # expect(actual_xml_element).to be_equivalent_to(@expected_full_xml_element)
     end
 
-    it 'should return a basic xml element for a valid druid and empty xml element' do
+    it 'returns a basic xml element for a valid druid and empty xml element' do
       actual_xml_element =  cm_generator_instance_with_druid.generate_xml_doc ''
       expect(actual_xml_element.to_xml).to eq(@expected_empty_xml_element.to_xml)
     end
 
-    it 'should return a basic xml element for a valid druid and empty xml element' do
+    it 'returns a basic xml element for a valid druid and empty xml element' do
       actual_xml_element =  cm_generator_instance_with_druid.generate_xml_doc
       expect(actual_xml_element.to_xml).to eq(@expected_empty_xml_element.to_xml)
     end
   end
 
   describe '.create_thumbnail_xml_element' do
-    it 'should return valid xml element for a regular image', :image_prerequisite do
+    it 'returns valid xml element for a regular image', :image_prerequisite do
       thumbnail_file_location = "#{@staging_path}/thumbnail_files/thumbnail.jp2"
       actual_xml_element = cm_generator_instance.create_thumbnail_xml_element thumbnail_file_location
       expect(actual_xml_element).to eq(@expected_thumbnal_xml_element)
@@ -73,24 +73,24 @@ RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
       # expect(actual_xml_object).to be_equivalent_to(expected_xml_objet)
     end
 
-    it 'should return empty string for non-existing images' do
+    it 'returns empty string for non-existing images' do
       thumbnail_file_location = "#{@staging_path}/thumbnail_files/nonthing.jpeg"
       actual_xml_element = cm_generator_instance.create_thumbnail_xml_element thumbnail_file_location
       expect(actual_xml_element).to eq('')
     end
 
-    it 'should return empty string for null location string' do
+    it 'returns empty string for null location string' do
       actual_xml_element = cm_generator_instance.create_thumbnail_xml_element nil
       expect(actual_xml_element).to eq('')
     end
 
-    it 'should raise an excetion for reading an empty image' do
+    it 'raises an excetion for reading an empty image' do
       # TODO: ? This test case should be fixed with adding an empty image
       thumbnail_file_location = "#{@staging_path}/thumbnail_files/thumbnail_empty.jpeg"
       expect { create_thumbnail_xml_element thumbnail_file_location }.to raise_error StandardError
     end
 
-    it 'should raise an error for reading an invalid image' do
+    it 'raises an error for reading an invalid image' do
       thumbnail_file_location = "#{@staging_path}/thumbnail_files/thumbnail_text.jpeg"
       expect { create_thumbnail_xml_element thumbnail_file_location }.to raise_error StandardError
     end


### PR DESCRIPTION


## Why was this change made? 🤔
Say what it does. 'Should' leaves ambiguity where none should be present


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


