### PR TITLE
wasDissemination checks for webarchive-binary

### DIFF
--- a/lib/robots/dor_repo/was_dissemination/start_special_dissemination.rb
+++ b/lib/robots/dor_repo/was_dissemination/start_special_dissemination.rb
@@ -15,7 +15,7 @@ module Robots
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'Not an item/DRO, nothing to do') unless obj.dro?
 
           # Theres nothing to do if this is a seed file
-          return LyberCore::Robot::ReturnState.new(status: :skipped, note: "Nothing to do for #{obj.type}") unless obj.type == Cocina::Models::ObjectType.object
+          return LyberCore::Robot::ReturnState.new(status: :skipped, note: "Nothing to do for #{obj.type}") unless obj.type == Cocina::Models::ObjectType.webarchive_binary
 
           workflow_service.create_workflow_by_name(druid, 'wasCrawlDisseminationWF', version: obj.version)
         end

--- a/spec/robots/dor_repo/was_dissemination/start_special_dissemination_spec.rb
+++ b/spec/robots/dor_repo/was_dissemination/start_special_dissemination_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Robots::DorRepo::WasDissemination::StartSpecialDissemination do
       end
 
       context 'when the type is object (crawl item)' do
-        let(:type) { Cocina::Models::ObjectType.object }
+        let(:type) { Cocina::Models::ObjectType.webarchive_binary }
 
         it 'initializes wasCrawlDisseminationWF for the crawl item' do
           perform


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #462. The start_special_dissemination workflow step needs to look for webarchive-binary object type now instead of object, with updates to the wasCrawlPreassembly workflow.

## How was this change tested? 🤨
Unit tests

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


