### PR TITLE
Copies path-index to directory used by pywb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,3 +161,30 @@ RSpec/FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
 RSpec/Rails/AvoidSetupHook: # new in 2.4
   Enabled: true
+
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ChangeByZero: # new in 2.11.0
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,7 +6,7 @@ Bundler.require(:default)
 environment = ENV['ROBOT_ENVIRONMENT'] ||= 'development'
 ROBOT_ROOT = File.expand_path(File.join(__dir__, '..'))
 ROBOT_LOG = Logger.new(File.join(ROBOT_ROOT, "log/#{environment}.log"))
-ROBOT_LOG.level = Logger::SEV_LABEL.index(ENV['ROBOT_LOG_LEVEL']) || Logger::INFO
+ROBOT_LOG.level = Logger::SEV_LABEL.index(ENV.fetch('ROBOT_LOG_LEVEL', nil)) || Logger::INFO
 
 loader = Zeitwerk::Loader.new
 loader.push_dir(File.absolute_path("#{__FILE__}/../../lib"))
@@ -47,4 +47,4 @@ Was.connect_dor_services_app
 
 # Load Resque configuration and controller
 require 'resque'
-Resque.redis = (defined? REDIS_URL) ? REDIS_URL : "localhost:6379/resque:#{ENV['ROBOT_ENVIRONMENT']}"
+Resque.redis = (defined? REDIS_URL) ? REDIS_URL : "localhost:6379/resque:#{ENV.fetch('ROBOT_ENVIRONMENT', nil)}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,11 @@ was_crawl_dissemination:
 
   path_working_directory: "/web-archiving-stacks/data/indices/path_working/"
   main_path_index_file: "/web-archiving-stacks/data/indices/path/path-index.txt"
+  # when in production with pywb, new settings for path:
+  # path_working_directory: "/web-archiving-stacks/data/indexes/path_working/" 
+  # main_path_index_file: "/web-archiving-stacks/data/indexes/path/path-index.txt"
+  # Needed only while pywb is run in parallel with openwayback:
+  pywb_main_path_index_file: "/web-archiving-stacks/data/indexes/path/path-index.txt"
 
   cdx_indexer_script: "jar/openwayback/bin/cdx-indexer"
   stacks_collections_path: "/web-archiving-stacks/data/collections/"

--- a/lib/dor/was_crawl/path_indexer_service.rb
+++ b/lib/dor/was_crawl/path_indexer_service.rb
@@ -7,6 +7,7 @@ module Dor
         @collection_path = collection_path
 
         @main_path_index_file = Settings.was_crawl_dissemination.main_path_index_file
+        @pywb_main_path_index_file = Settings.was_crawl_dissemination.pywb_main_path_index_file
 
         @working_merged_path_index = "#{path_working_directory}/merged_path_index.txt"
         @working_sorted_duplicate_path_index = "#{path_working_directory}/duplicate_path_index.txt"
@@ -39,6 +40,11 @@ module Dor
 
       def publish
         FileUtils.mv(@working_sorted_path_index, @main_path_index_file)
+      end
+
+      # Needed only while pywb is run in parallel with openwayback
+      def copy
+        FileUtils.cp(@main_path_index_file, @pywb_main_path_index_file)
       end
 
       def clean

--- a/lib/robots/dor_repo/was_crawl_dissemination/path_indexer.rb
+++ b/lib/robots/dor_repo/was_crawl_dissemination/path_indexer.rb
@@ -22,6 +22,8 @@ module Robots
           path_indexer_service.merge
           path_indexer_service.sort
           path_indexer_service.publish
+          # copy needed only while pywb is run in parallel with openwayback
+          path_indexer_service.copy
           path_indexer_service.clean
         end
       end

--- a/spec/lib/dor/was_crawl/cdx_generator_service_spec.rb
+++ b/spec/lib/dor/was_crawl/cdx_generator_service_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
         cdx_file_path_1 = "#{@stacks_path}/data/indices/cdx_working/#{@druid_id_1}/WARC-Test.cdx"
         cdx_file_path_2 = "#{@stacks_path}/data/indices/cdx_working/#{@druid_id_1}/ARC-Test.cdx"
 
-        expect(File.exist?(cdx_file_path_1)).to eq(true)
-        expect(File.exist?(cdx_file_path_2)).to eq(true)
+        expect(File.exist?(cdx_file_path_1)).to be(true)
+        expect(File.exist?(cdx_file_path_2)).to be(true)
 
         actual_cdx_MD5 = Digest::MD5.hexdigest(File.read(cdx_file_path_1))
         expected_cdx_MD5 = Digest::MD5.hexdigest(File.read('spec/fixtures/cdx_files/WARC-Test.cdx'))
@@ -55,7 +55,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       it 'generates cdx files for each warc or arc file in contentMetadata even if there are some file already created', :openwayback_prerequisite do
         # Make sure the test case is correctly setup
         cdx_file_path_1 = "#{@stacks_path}/data/indices/cdx_working/#{@druid_id_2}/WARC-Test.cdx"
-        expect(File.exist?(cdx_file_path_1)).to eq(true)
+        expect(File.exist?(cdx_file_path_1)).to be(true)
 
         cdx_generator = described_class.new(@collection_path, @druid_id_2, warc_file_list)
 
@@ -65,8 +65,8 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
         cdx_file_path_1 = "#{@stacks_path}/data/indices/cdx_working/#{@druid_id_2}/WARC-Test.cdx"
         cdx_file_path_2 = "#{@stacks_path}/data/indices/cdx_working/#{@druid_id_2}/ARC-Test.cdx"
 
-        expect(File.exist?(cdx_file_path_1)).to eq(true)
-        expect(File.exist?(cdx_file_path_2)).to eq(true)
+        expect(File.exist?(cdx_file_path_1)).to be(true)
+        expect(File.exist?(cdx_file_path_2)).to be(true)
 
         actual_cdx_MD5   = Digest::MD5.hexdigest(File.read(cdx_file_path_1))
         expected_cdx_MD5 = Digest::MD5.hexdigest(File.read('spec/fixtures/cdx_files/WARC-Test.cdx'))
@@ -88,8 +88,8 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
 
         cdx_dir = "#{@stacks_path}/data/indices/cdx_working/#{@druid_id_3}/"
 
-        expect(File.exist?(cdx_dir)).to eq(true)
-        expect(Dir.glob("#{cdx_dir}{*,.*}").empty?).to eq(true)
+        expect(File.exist?(cdx_dir)).to be(true)
+        expect(Dir.glob("#{cdx_dir}{*,.*}").empty?).to be(true)
       end
     end
   end
@@ -109,7 +109,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       warc_file_path = "#{@workspace}/aa111aa1111/WARC-Test.warc.gz"
       @cdx_generator.generate_cdx_for_one_warc(warc_file_path, cdx_file_path)
 
-      expect(File.exist?(cdx_file_path)).to eq(true)
+      expect(File.exist?(cdx_file_path)).to be(true)
 
       actual_cdx_MD5 = Digest::MD5.hexdigest(File.read(cdx_file_path))
       expected_cdx_MD5 = Digest::MD5.hexdigest(File.read('spec/fixtures/cdx_files/WARC-Test.cdx'))
@@ -121,7 +121,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       warc_file_path = "#{@workspace}/cc111cc1111/ARC-Test.arc.gz"
       @cdx_generator.generate_cdx_for_one_warc(warc_file_path, cdx_file_path)
 
-      expect(File.exist?(cdx_file_path)).to eq(true)
+      expect(File.exist?(cdx_file_path)).to be(true)
 
       actual_cdx_MD5 = Digest::MD5.hexdigest(File.read(cdx_file_path))
       expected_cdx_MD5 = Digest::MD5.hexdigest(File.read('spec/fixtures/cdx_files/ARC-Test.cdx'))
@@ -205,7 +205,7 @@ RSpec.describe Dor::WasCrawl::CdxGeneratorService do
       cmd_string = "jar/openwayback/bin/cdx-indexer  #{warc_file_name} #{cdx_file_name} 2>> log/cdx_indexer.log"
       Dor::WasCrawl::Dissemination::Utilities.run_sys_cmd(cmd_string, 'extracting CDX')
 
-      expect(File.exist?(cdx_file_name)).to eq(true)
+      expect(File.exist?(cdx_file_name)).to be(true)
 
       actual_cdx_MD5 = Digest::MD5.hexdigest(File.read(cdx_file_name))
       expected_cdx_MD5 = Digest::MD5.hexdigest(File.read('spec/fixtures/cdx_files/WARC-Test.cdx'))

--- a/spec/lib/dor/was_crawl/cdx_merge_sort_publish_service_spec.rb
+++ b/spec/lib/dor/was_crawl/cdx_merge_sort_publish_service_spec.rb
@@ -22,7 +22,7 @@ describe Dor::WasCrawl::CdxMergeSortPublishService do
 
       expected_merged_file_path = "#{cdx_file_path}/#{druid}_merged_index.cdx"
       actual_merged_file_path = "#{@cdx_working_dir}/#{druid}_merged_index.cdx"
-      expect(File.exist?(actual_merged_file_path)).to eq true
+      expect(File.exist?(actual_merged_file_path)).to be true
 
       actual_cdx_MD5 = Digest::MD5.hexdigest(File.read(actual_merged_file_path))
       expected_cdx_MD5 = Digest::MD5.hexdigest(File.read(expected_merged_file_path))
@@ -45,7 +45,7 @@ describe Dor::WasCrawl::CdxMergeSortPublishService do
 
       expected_sorted = "#{cdx_file_path}/#{druid}_sorted_index.cdx"
       actual_sorted = "#{@cdx_working_dir}/#{druid}_sorted_index.cdx"
-      expect(File.exist?(actual_sorted)).to eq true
+      expect(File.exist?(actual_sorted)).to be true
       actual_cdx_MD5 = Digest::MD5.hexdigest(File.read(actual_sorted))
       expected_cdx_MD5 = Digest::MD5.hexdigest(File.read(expected_sorted))
       expect(actual_cdx_MD5).to eq expected_cdx_MD5
@@ -68,12 +68,12 @@ describe Dor::WasCrawl::CdxMergeSortPublishService do
 
       mergeSortPublishService = described_class.new(druid, @cdx_working_dir, '')
       mergeSortPublishService.instance_variable_set(:@main_cdx_file, @main_cdx_file)
-      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@working_sorted_cdx))).to eq true
-      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@main_cdx_file))).to eq false
+      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@working_sorted_cdx))).to be true
+      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@main_cdx_file))).to be false
 
       mergeSortPublishService.publish
-      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@working_sorted_cdx))).to eq false
-      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@main_cdx_file))).to eq true
+      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@working_sorted_cdx))).to be false
+      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@main_cdx_file))).to be true
     end
   end
 
@@ -92,30 +92,30 @@ describe Dor::WasCrawl::CdxMergeSortPublishService do
       FileUtils.cp_r("#{cdx_file_path}/ii/.", @cdx_working_dir)
       mergeSortPublishService = described_class.new(@druid, @cdx_working_dir, @cdx_backup_dir)
 
-      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@source_cdx_dir))).to eq true
-      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_merged_index.cdx")).to eq true
-      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_sorted_duplicate_index.cdx")).to eq true
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file1.cdx")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file2.cdx")).to eq false
+      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@source_cdx_dir))).to be true
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_merged_index.cdx")).to be true
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_sorted_duplicate_index.cdx")).to be true
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to be false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file1.cdx")).to be false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file2.cdx")).to be false
 
       mergeSortPublishService.clean
-      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@source_cdx_dir))).to eq false
-      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_merged_index.cdx")).to eq false
-      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_sorted_duplicate_index.cdx")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to eq true
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file1.cdx")).to eq true
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file2.cdx")).to eq true
+      expect(File.exist?(mergeSortPublishService.instance_variable_get(:@source_cdx_dir))).to be false
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_merged_index.cdx")).to be false
+      expect(File.exist?("#{@cdx_working_dir}/#{@druid}_sorted_duplicate_index.cdx")).to be false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to be true
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file1.cdx")).to be true
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}/file2.cdx")).to be true
       # merged_index.cdx and sorted_duplicate_index.cdx are not kept
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}_merged_index.cdx")).to eq false
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}_sorted_duplicate_index.cdx")).to eq false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}_merged_index.cdx")).to be false
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}_sorted_duplicate_index.cdx")).to be false
     end
 
     it 'moves cdx files to cdx backup directory when the @druid directory already exists' do
       FileUtils.cp_r("#{cdx_file_path}/ii/.", @cdx_backup_dir)
 
       mergeSortPublishService = described_class.new(@druid, @cdx_working_dir, @cdx_backup_dir)
-      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to eq true
+      expect(File.exist?("#{@cdx_backup_dir}/#{@druid}")).to be true
 
       # it's okay if it complains about the files;  we are specifically concerned about the directory
       expect { mergeSortPublishService.clean }.not_to raise_error(StandardError, "File exists - #{@cdx_backup_dir}/#{@druid}")

--- a/spec/lib/dor/was_crawl/path_indexer_service_spec.rb
+++ b/spec/lib/dor/was_crawl/path_indexer_service_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe Dor::WasCrawl::PathIndexerService do
     end
   end
 
+  # Needed only while pywb is run in parallel with openwayback
+  describe '#copy' do
+    after(:all) do
+      FileUtils.rm("#{@stacks_path}/data/indexes/path/test_path-index.txt")
+    end
+
+    it 'copies the openwayback path index to the pywb location' do
+      path_index_service = described_class.new(@druid, @collection_path, @path_working_directory, [])
+      FileUtils.cp("#{@path_files}/path_index.txt", "#{@stacks_path}/data/indices/path/test_path-index.txt")
+
+      path_index_service.instance_variable_set(:@main_path_index_file, "#{@stacks_path}/data/indices/path/test_path-index.txt")
+      path_index_service.instance_variable_set(:@pywb_main_path_index_file, "#{@stacks_path}/data/indexes/path/test_path-index.txt")
+
+      path_index_service.copy
+
+      pywb_path_index_file = "#{@stacks_path}/data/indexes/path/test_path-index.txt"
+      expect(File.exist?(pywb_path_index_file)).to eq(true)
+    end
+  end
+
   describe '.clean' do
     pending
   end

--- a/spec/lib/dor/was_crawl/path_indexer_service_spec.rb
+++ b/spec/lib/dor/was_crawl/path_indexer_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Dor::WasCrawl::PathIndexerService do
 
       expected_merged_file_path = "#{@path_files}/merged_path_index.txt"
       actual_merged_file_path = "#{@path_working_directory}/merged_path_index.txt"
-      expect(File.exist?(actual_merged_file_path)).to eq(true)
+      expect(File.exist?(actual_merged_file_path)).to be(true)
 
       expect(File.read(actual_merged_file_path)).to eq(File.read(expected_merged_file_path))
     end
@@ -36,13 +36,13 @@ RSpec.describe Dor::WasCrawl::PathIndexerService do
       expected_duplicate_path_index = "#{@path_files}/duplicate_path_index.txt"
       actual_duplicate_path_index = "#{@path_working_directory}/duplicate_path_index.txt"
 
-      expect(File.exist?(actual_duplicate_path_index)).to eq(true)
+      expect(File.exist?(actual_duplicate_path_index)).to be(true)
       expect(File.read(actual_duplicate_path_index)).to eq(File.read(expected_duplicate_path_index))
 
       expected_path_index = "#{@path_files}/path_index.txt"
       actual_path_index = "#{@path_working_directory}/path_index.txt"
 
-      expect(File.exist?(actual_path_index)).to eq(true)
+      expect(File.exist?(actual_path_index)).to be(true)
       expect(File.read(actual_path_index)).to eq(File.read(expected_path_index))
     end
   end
@@ -61,7 +61,7 @@ RSpec.describe Dor::WasCrawl::PathIndexerService do
       path_index_service.publish
 
       actual_path_index = "#{@stacks_path}/data/indices/path/test_path-index.txt"
-      expect(File.exist?(actual_path_index)).to eq(true)
+      expect(File.exist?(actual_path_index)).to be(true)
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.describe Dor::WasCrawl::PathIndexerService do
       path_index_service.copy
 
       pywb_path_index_file = "#{@stacks_path}/data/indexes/path/test_path-index.txt"
-      expect(File.exist?(pywb_path_index_file)).to eq(true)
+      expect(File.exist?(pywb_path_index_file)).to be(true)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Closes #466. Sets up the path-indexer step to make a copy of the existing file to the directory used by pywb, allowing pywb and openwayback to run in parallel. 


## How was this change tested? 🤨
Unit tests

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


