### PR TITLE
cdxj-indexer path

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -194,4 +194,4 @@ Style/TernaryParentheses:
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, IgnoredPatterns.
 # URISchemes: http, https
 Layout/LineLength:
-  Max: 209
+  Max: 225 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,7 @@ was_crawl_dissemination:
   sort_env_vars: "TMPDIR=/web-archiving-stacks/data/tmp/ LC_ALL=C"
 
 cdxj_indexer:
+  bin: /opt/app/was/.local/bin/cdxj-indexer
   working_directory: /web-archiving-stacks/data/indexes/cdxj_working
   backup_directory: /web-archiving-stacks/data/indexes/cdxj_backup
   main_cdxj_file: /web-archiving-stacks/data/indexes/cdxj/level0.cdxj

--- a/lib/dor/was_crawl/cdxj_generator_service.rb
+++ b/lib/dor/was_crawl/cdxj_generator_service.rb
@@ -31,7 +31,7 @@ module Dor
       def generate_cdx_for_one_warc(warc_file_name)
         cdx_file_path  = cdx_file_name(warc_file_name)
         warc_file_path = "#{druid_base_directory}/#{warc_file_name}"
-        cmd_string = "cdxj-indexer #{warc_file_path} --output #{cdx_file_path} --sort --post-append 2>> log/cdx_indexer.log"
+        cmd_string = "#{Settings.cdxj_indexer.bin} #{warc_file_path} --output #{cdx_file_path} --sort --post-append 2>> log/cdx_indexer.log"
         Dor::WasCrawl::Dissemination::Utilities.run_sys_cmd(cmd_string, 'extracting CDXJ')
       end
     end

--- a/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Robots::DorRepo::WasCrawlDissemination::CdxjGenerator do
     it 'runs the cdxj-indexer' do
       perform
       expect(Dor::WasCrawl::Dissemination::Utilities).to have_received(:run_sys_cmd)
-        .with('cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/foo/number1.warc --output tmp/druid:dd116zh0343/number1.cdxj --sort --post-append 2>> log/cdx_indexer.log',
+        .with('/opt/app/was/.local/bin/cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/foo/number1.warc --output tmp/druid:dd116zh0343/number1.cdxj --sort --post-append 2>> log/cdx_indexer.log',
               "extracting CDXJ")
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Hard code the full path to where pip3 installs cdxj-indexer in the `was` user's home directory. Available via `Settings.cdxj_indexer.bin`. From #468 it appears that resque workers are not running with ` /opt/app/was/.local/bin/` in their PATH. This location is set for logins via `/opt/app/was/.profile` but presumably not for resque workers?

Fixes #468 

## How was this change tested? 🤨

Unit tests.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


