### PR TITLE
Fix doc URL

### DIFF
--- a/lib/dor/was_crawl/cdxj_merge_service.rb
+++ b/lib/dor/was_crawl/cdxj_merge_service.rb
@@ -76,7 +76,8 @@ module Dor
       end
 
       def sort_env_vars
-        # See http://iipc.github.io/warc-specifications/specifications/cdx-format/openwayback-cdxj/#sorting-file--index
+        # Ensure that the index is sorted by byte values
+        # See https://specs.webrecorder.net/cdxj/0.1.0/#sorting
         "LC_ALL=C"
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

The CDXJ doumentation recently got yanked from the IIPC website! Since CDXJ is an idea that was largely started by the Webrecorder project we can link there since it's no longer available on the IIPC website. 

And people wonder why we need web archives :)

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


