### PR TITLE
Change hard-coded SWAP URL to use configuration

### DIFF
--- a/lib/dor/was_seed/metadata_generator.rb
+++ b/lib/dor/was_seed/metadata_generator.rb
@@ -26,7 +26,9 @@ module Dor
       end
 
       def read_template(metadata_name)
-        File.read(Pathname(File.dirname(__FILE__)).join("../../../template/wasSeedPreassembly/#{metadata_name}.xslt"))
+        ERB.new(
+          File.read(Pathname(File.dirname(__FILE__)).join("../../../template/wasSeedPreassembly/#{metadata_name}.xslt"))
+        ).result
       end
 
       def transform_xml_using_xslt(metadata_xml_input_object, metadata_xslt_template)

--- a/template/wasSeedPreassembly/descMetadata.xslt
+++ b/template/wasSeedPreassembly/descMetadata.xslt
@@ -26,7 +26,7 @@
                  <digitalOrigin>born digital</digitalOrigin>
              </physicalDescription>
              <location>
-                 <url displayLabel="Archived website">https://swap.stanford.edu/*/<xsl:value-of select="uri"/></url>
+                 <url displayLabel="Archived website"><%= Settings.was_seed.wayback_uri %>/*/<xsl:value-of select="uri"/></url>
              </location>
              <recordInfo>
                  <languageOfCataloging>


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to sul-dlss/was-pywb#16

Note that these configs are already in place, defaulting to the current prod SWAP URL, with overrides in shared_configs for QA and stage.

## How was this change tested? 🤨

Tested in stage and verified that both QA and prod have this configuration correctly set.
