### PR TITLE
Rake tasks for rolling up cdxj indexes

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,12 +3,15 @@ set :environment_variable, 'ROBOT_ENVIRONMENT'
 
 every 1.day, roles: [:rollup] do
   rake 'cdx:index:rollup:level1'
+  rake 'cdxj:index:rollup:level1'
 end
 
 every 1.month, roles: [:rollup] do
   rake 'cdx:index:rollup:level2'
+  rake 'cdxj:index:rollup:level2'
 end
 
 every 12.months, roles: [:rollup] do
   rake 'cdx:index:rollup:level3'
+  rake 'cdxj:index:rollup:level3'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,6 +25,7 @@ was_crawl_dissemination:
   cdx_working_directory: "/web-archiving-stacks/data/indices/cdx_working/"
   cdx_backup_directory: "/web-archiving-stacks/data/indices/cdx_backup/"
   main_cdx_file: "/web-archiving-stacks/data/indices/cdx/level0.cdx"
+  main_cdxj_file: "/web-archiving-stacks/data/indexes/cdxj/level0.cdxj"
 
   path_working_directory: "/web-archiving-stacks/data/indices/path_working/"
   main_path_index_file: "/web-archiving-stacks/data/indices/path/path-index.txt"

--- a/lib/dor/was_crawl/cdxj_rollup_service.rb
+++ b/lib/dor/was_crawl/cdxj_rollup_service.rb
@@ -1,0 +1,51 @@
+module Dor
+  module WasCrawl
+    class CdxjRollupService
+      def initialize(level, index_dir)
+        @level = level
+        @index_dir = index_dir
+      end
+
+      # level is the index level from which to rollup
+      def rollup
+        src = @index_dir.join("level#{@level}.cdxj")
+        dst = @index_dir.join("level#{@level + 1}.cdxj")
+
+        # ensure only 1 rollup process at a time, and robots should use the
+        # working.lock file to also to block while rollup work is being done
+        Lockfile.new(@index_dir.join('working.lock').to_s) do
+          raise "Missing #{src} file" unless src.exist?
+          raise "Missing #{dst} file" unless dst.exist?
+
+          if src.zero?
+            puts "Nothing to do. No data in #{src}"
+          else
+            merge(src, dst)
+          end
+        end
+      end
+
+      def merge(src, dst)
+        # we need to merge the 2 *already sorted* files into the new file, and
+        # then zero out the current level of index
+        cmd = "#{sort_env_vars} sort --merge --unique --output=#{dst}.new #{src} #{dst}"
+        puts "Merging via #{cmd}"
+        if system(cmd)
+          FileUtils.mv("#{dst}.new", dst.to_s)
+          FileUtils.rm(src.to_s)
+          FileUtils.touch(src.to_s)
+          puts "Rolled up level#{@level} into level#{@level + 1} CDXJ index"
+        else
+          puts "Failed to roll up level#{@level} into level#{@level + 1} CDXJ index. Cleaning up..."
+          FileUtils.rm("#{dst}.new")
+        end
+      end
+
+      def sort_env_vars
+        # Ensure that the index is sorted by byte values
+        # See https://specs.webrecorder.net/cdxj/0.1.0/#sorting
+        "LC_ALL=C"
+      end
+    end
+  end
+end

--- a/spec/lib/dor/was_crawl/cdxj_rollup_service_spec.rb
+++ b/spec/lib/dor/was_crawl/cdxj_rollup_service_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dor::WasCrawl::CdxjRollupService do
+  describe '#rollup' do
+    subject(:rollup_service) { described_class.new(level, index_dir) }
+
+    let(:index_dir) { Pathname.new("tmp/cdxj") }
+    let(:main_file) { "#{index_dir}/level0.cdxj" }
+    let(:main_file1) { "#{index_dir}/level1.cdxj" }
+    let(:level) { 0 }
+
+    before do
+      FileUtils.makedirs index_dir unless File.exist?(index_dir)
+      File.write(main_file, "AG\nBG\nCG")
+      File.write(main_file1, "AA\nBG\nBH\nCI")
+    end
+
+    after do
+      FileUtils.rm_r index_dir
+    end
+
+    it 'rolls up level0 into level1' do
+      rollup_service.rollup
+      expect(File.read(main_file1)).to eq 'AA
+AG
+BG
+BH
+CG
+CI
+'
+      expect(File.read(main_file)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Adding regular schedule to roll up cdxj files. Fixes #450.


## How was this change tested? 🤨
Unit and adding a test. Tested level0 > level1 rollup on QA.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


