### PR TITLE
adjust code coverage settings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,12 @@
 ENV['ROBOT_ENVIRONMENT'] = 'test'
 
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start :rails do
+  add_filter '/bin/'
+  add_filter '/config/'
+  add_filter '/spec/'
+  add_filter '/vendor/'
+end
 
 require File.expand_path("#{__dir__}/../config/boot")
 require 'rspec'


### PR DESCRIPTION
## Why was this change made? 🤔

I have the codeclimate plugin for my browser installed, and I was seeing spec code blocks that "weren't covered" which is silly.  This should up the percentage covered by a bit.

## How was this change tested? 🤨

it's a configuration.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


