### PR TITLE
Raise an error when the uri is not indexed before thumbnail generation

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,7 @@ cdxj_indexer:
   working_directory: /web-archiving-stacks/data/indexes/cdxj_working
   backup_directory: /web-archiving-stacks/data/indexes/cdxj_backup
   main_cdxj_file: /web-archiving-stacks/data/indexes/cdxj/level0.cdxj
+  url: ~
 
 was_seed:
   workspace_path: '/dor/workspace/'  #the root for the storage for DRUID tree that will be the input to AssemblyWF

--- a/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
@@ -76,4 +76,29 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
       expect(FileUtils.compare_file(temporary_image, 'spec/was_seed_preassembly/fixtures/thumbnail_files/thum_extra_height.jpeg')).to be_truthy
     end
   end
+
+  describe '.indexed?' do
+    let(:uri) { 'http://www.slac.stanford.edu' }
+
+    context 'when the uri is found in the cdxj index' do
+      let(:response_body) { { body: 'some content' } }
+      let(:response) { Net::HTTPSuccess.new(1.0, '200', 'OK') }
+
+      it 'returns nil when the uri is found in the index' do
+        allow(Net::HTTP).to receive(:get_response).and_return(response)
+        allow(response).to receive(:body).and_return(response_body)
+        expect(described_class.indexed?(uri)).to be_nil
+      end
+    end
+
+    context 'when the uri is not found in the cdxj index' do
+      let(:response) { Net::HTTPSuccess.new(1.0, '200', 'OK') }
+
+      it 'returns nil when the uri is found in the index' do
+        allow(Net::HTTP).to receive(:get_response).and_return(response)
+        allow(response).to receive(:body).and_return(nil)
+        expect { described_class.indexed?(uri) }.to raise_error.with_message("#{uri} not found in cdxj index.")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #475 

The Settings updates below have been added to shared_configs for stage and qa with an open PR for prod.

## How was this change tested? 🤨

unit test added.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


