### PR TITLE
refactor thumbnail_generator_service for clarity

### DIFF
--- a/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
@@ -21,22 +21,22 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
     end
 
     it 'generates jp2 from jpeg thumbnail and pushes to druid_tree content directory', :image_prerequisite do
-      allow(described_class).to receive(:capture)
+      allow(described_class).to receive(:screenshot).and_call_original
       described_class.capture_thumbnail(@druid_id, @workspace, @uri)
       expect(File.exist?('spec/was_seed_preassembly/fixtures/workspace/ab/123/cd/4567/ab123cd4567/content/thumbnail.jp2')).to be true
       expect(File.exist?('tmp/ab123cd4567.jpeg')).to be false
     end
 
-    it 'raises an error if the capture method raises an exception' do
-      allow(described_class).to receive(:capture).and_raise('Error')
-      exp_msg = "Thumbnail for druid druid:ab123cd4567 and http://www.slac.stanford.edu can't be generated.\n Error"
+    it 'raises an error if the screenshot method raises an exception' do
+      allow(described_class).to receive(:screenshot).and_raise('Foo')
+      exp_msg = "Thumbnail for druid druid:ab123cd4567 and http://www.slac.stanford.edu can't be generated.\n Foo"
       expect { described_class.capture_thumbnail(@druid_id, @workspace, @uri) }.to raise_error.with_message(exp_msg)
       expect(File.exist?('spec/was_seed_preassembly/fixtures/workspace/ab/123/cd/4567/ab123cd4567/content/thumbnail.jp2')).to be false
       expect(File.exist?('tmp/ab123cd4567.jpeg')).to be false
     end
   end
 
-  describe '.capture' do
+  describe '.screenshot' do
     before do
       FileUtils.rm 'tmp/test_capture.jpeg', force: true
     end
@@ -50,13 +50,13 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
       VCR.use_cassette('slac_capture') do
         wayback_uri = 'https://swap.stanford.edu/20110202032021/http://www.slac.stanford.edu'
         temporary_file = 'tmp/test_capture'
-        result = described_class.capture(wayback_uri, temporary_file)
+        result = described_class.screenshot(wayback_uri, temporary_file)
         expect(result).to eq('')
       end
     end
   end
 
-  describe '.resize_temporary_image', :image_prerequisite do
+  describe '.resize_jpeg', :image_prerequisite do
     after do
       FileUtils.rm 'tmp/thum_extra_width.jpeg', force: true
       FileUtils.rm 'tmp/thum_extra_height.jpeg', force: true
@@ -65,14 +65,14 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
     it 'resizes the image with extra width to maximum 400 pixel width' do
       temporary_image = 'tmp/thum_extra_width.jpeg'
       FileUtils.cp 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_width.jpeg', temporary_image
-      described_class.resize_temporary_image temporary_image
+      described_class.resize_jpeg temporary_image
       expect(FileUtils.compare_file(temporary_image, 'spec/fixtures/thumbnail_files/thum_extra_width.jpeg')).to be_truthy
     end
 
     it 'resizes the image with extra height to maximum 400 pixel height', :image_prerequisite do
       temporary_image = 'tmp/thum_extra_height.jpeg'
       FileUtils.cp 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_height.jpeg', temporary_image
-      described_class.resize_temporary_image temporary_image
+      described_class.resize_jpeg temporary_image
       expect(FileUtils.compare_file(temporary_image, 'spec/was_seed_preassembly/fixtures/thumbnail_files/thum_extra_height.jpeg')).to be_truthy
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

To make it easier to switch to vips instead of ImageMagick

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


