### PR TITLE
.resize_jpeg tests pass using vips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'rake'
 gem 'resque'
 gem 'resque-pool'
 gem 'rubyzip'        # warc_extractor_service
+gem 'ruby-vips'      # image processing for thumbnail creation
 gem 'slop'           # for bin/run_robot
 gem 'whenever'       # for cron jobs
 gem 'zeitwerk', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ DEPENDENCIES
   rspec
   rubocop
   rubocop-rspec
+  ruby-vips
   rubyzip
   simplecov
   slop

--- a/lib/dor/was_seed/thumbnail_generator_service.rb
+++ b/lib/dor/was_seed/thumbnail_generator_service.rb
@@ -31,6 +31,7 @@ module Dor
         raise stderr_str unless File.exist?(screenshot_jpeg)
       end
 
+      # resizes the passed jpeg image to a 400 px max and replaces the original file with the resized image
       def self.resize_jpeg(jpeg_file)
         image = MiniMagick::Image.open(jpeg_file)
         width = image.width

--- a/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'vips'
+
 RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
   before do
     Settings.was_seed.wayback_uri = 'https//swap.stanford.edu'
@@ -46,7 +48,8 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
     end
 
     it 'captures jpeg image for the first capture of url', :image_prerequisite do
-      pending 'fails from jquery error'
+      # FIXME: We have NO TEST EXECUTING FOR THIS METHOD!
+      pending 'fails from lack of VCR cassette and maybe also jquery error'
       VCR.use_cassette('slac_capture') do
         wayback_uri = 'https://swap.stanford.edu/20110202032021/http://www.slac.stanford.edu'
         temporary_file = 'tmp/test_capture'
@@ -56,24 +59,44 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
     end
   end
 
-  describe '.resize_jpeg', :image_prerequisite do
+  describe '.resize_jpeg' do
     after do
       FileUtils.rm 'tmp/thum_extra_width.jpeg', force: true
       FileUtils.rm 'tmp/thum_extra_height.jpeg', force: true
     end
 
     it 'resizes the image with extra width to maximum 400 pixel width' do
-      temporary_image = 'tmp/thum_extra_width.jpeg'
-      FileUtils.cp 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_width.jpeg', temporary_image
-      described_class.resize_jpeg temporary_image
-      expect(FileUtils.compare_file(temporary_image, 'spec/fixtures/thumbnail_files/thum_extra_width.jpeg')).to be_truthy
+      original_file = 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_width.jpeg'
+      generated_thumb_file = 'tmp/thum_extra_width.jpeg'
+      FileUtils.cp(original_file, generated_thumb_file)
+      described_class.resize_jpeg(generated_thumb_file)
+
+      original_image = Vips::Image.new_from_file(original_file)
+      expected_thumb_image = Vips::Image.new_from_file('spec/was_seed_preassembly/fixtures/thumbnail_files/thum_extra_width.jpeg')
+      generated_thumb_image = Vips::Image.new_from_file(generated_thumb_file)
+      expect(generated_thumb_image.width).to be < original_image.width
+      expect(generated_thumb_image.height).to be < original_image.height
+      expect(generated_thumb_image.width).to eq 400
+      expect(generated_thumb_image.height).to be < 400
+      # this comparison of the image content itself courtesy of Tony Calavano
+      expect((expected_thumb_image == generated_thumb_image).min).to be < 255.0
     end
 
-    it 'resizes the image with extra height to maximum 400 pixel height', :image_prerequisite do
-      temporary_image = 'tmp/thum_extra_height.jpeg'
-      FileUtils.cp 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_height.jpeg', temporary_image
-      described_class.resize_jpeg temporary_image
-      expect(FileUtils.compare_file(temporary_image, 'spec/was_seed_preassembly/fixtures/thumbnail_files/thum_extra_height.jpeg')).to be_truthy
+    it 'resizes the image with extra height to maximum 400 pixel height' do
+      original_file = 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_height.jpeg'
+      generated_thumb_file = 'tmp/thum_extra_height.jpeg'
+      FileUtils.cp(original_file, generated_thumb_file)
+      described_class.resize_jpeg(generated_thumb_file)
+
+      original_image = Vips::Image.new_from_file(original_file)
+      expected_thumb_image = Vips::Image.new_from_file('spec/was_seed_preassembly/fixtures/thumbnail_files/thum_extra_height.jpeg')
+      generated_thumb_image = Vips::Image.new_from_file(generated_thumb_file)
+      expect(generated_thumb_image.width).to be < original_image.width
+      expect(generated_thumb_image.height).to be < original_image.height
+      expect(generated_thumb_image.width).to be < 400
+      expect(generated_thumb_image.height).to eq 400
+      # this comparison of the image content itself courtesy of Tony Calavano
+      expect((expected_thumb_image == generated_thumb_image).min).to be < 255.0
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

part of issue #497 - get specs for `ThumbnailGeneratorService.resize_jpeg` passing

this is also on the way to issue #458

## How was this change tested? 🤨

this change is adding tests that should have been executing all along.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


