### PR TITLE
Refactor seed thumbnail generator spec

### DIFF
--- a/lib/dor/was_seed/thumbnail_generator_service.rb
+++ b/lib/dor/was_seed/thumbnail_generator_service.rb
@@ -8,12 +8,12 @@ module Dor
     class ThumbnailGeneratorService
       # because this date is earlier than any of the archived dates of the content,
       # this tells openwayback to provide the earliest capture date.
-      DATE_TO_TRIGGER_EARLIEST_CAPTURE_DATE = '19900101120000'
+      DATE_TO_TRIGGER_EARLIEST_CAPTURE = '19900101120000'
       def self.capture_thumbnail(druid, workspace, seed_uri)
         screenshot_jpeg = "tmp/#{druid.delete_prefix('druid:')}.jpeg"
         begin
           indexed?(seed_uri)
-          wayback_uri = "#{Settings.was_seed.wayback_uri}/#{DATE_TO_TRIGGER_EARLIEST_CAPTURE_DATE}/#{seed_uri}"
+          wayback_uri = "#{Settings.was_seed.wayback_uri}/#{DATE_TO_TRIGGER_EARLIEST_CAPTURE}/#{seed_uri}"
           screenshot(wayback_uri, screenshot_jpeg)
           resize_jpeg(screenshot_jpeg)
           thumbnail_file = "#{DruidTools::Druid.new(druid, workspace).content_dir}/thumbnail.jp2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,3 +19,33 @@ require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'cocina/rspec'
 require 'pry-byebug'
+
+# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+RSpec.configure do |config|
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  # config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  # config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  # Kernel.srand config.seed
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Part of #497, this PR gets rid of an :image_prerequisite tag on a spec and clarifies what is and isn't executed in by the spec.  Bonus:  add some of my favorite configurations for spec_helper.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


