### PR TITLE
adding --dir-root to cdxj-indexer command

### DIFF
--- a/lib/dor/was_crawl/cdxj_generator_service.rb
+++ b/lib/dor/was_crawl/cdxj_generator_service.rb
@@ -33,7 +33,7 @@ module Dor
       def generate_cdx_for_one_warc(warc_file_name)
         cdx_file_path  = cdx_file_name(warc_file_name)
         warc_file_path = "#{druid_base_directory}/#{warc_file_name}"
-        cmd_string = "#{Settings.cdxj_indexer.bin} #{warc_file_path} --output #{cdx_file_path} --post-append 2>> log/cdx_indexer.log"
+        cmd_string = "#{Settings.cdxj_indexer.bin} #{warc_file_path} --output #{cdx_file_path} --dir-root #{Settings.was_crawl_dissemination.stacks_collections_path} --post-append 2>> log/cdx_indexer.log"
         Dor::WasCrawl::Dissemination::Utilities.run_sys_cmd(cmd_string, 'extracting CDXJ')
       end
     end

--- a/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Robots::DorRepo::WasCrawlDissemination::CdxjGenerator do
     subject(:perform) { robot.perform(druid) }
 
     let(:druid) { 'druid:dd116zh0343' }
+    let(:sys_cmd) do
+      '/opt/app/was/.local/bin/cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc ' \
+        '--output tmp/druid:dd116zh0343/number1.cdxj --dir-root /web-archiving-stacks/data/collections/ --post-append 2>> log/cdx_indexer.log'
+    end
 
     before do
       allow(Dor::WasCrawl::Dissemination::Utilities).to receive(:run_sys_cmd)
@@ -18,8 +22,7 @@ RSpec.describe Robots::DorRepo::WasCrawlDissemination::CdxjGenerator do
     it 'runs the cdxj-indexer' do
       perform
       expect(Dor::WasCrawl::Dissemination::Utilities).to have_received(:run_sys_cmd)
-        .with('/opt/app/was/.local/bin/cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc --output tmp/druid:dd116zh0343/number1.cdxj --post-append 2>> log/cdx_indexer.log',
-              "extracting CDXJ")
+        .with(sys_cmd, "extracting CDXJ")
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #491 to include the path within the collections directory in the index, as in was-pywb's index.rb, using the --dir-root option. 


## How was this change tested? 🤨
Unit and on QA

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


