### PR TITLE
Content md gen spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
---tag=~image_prerequisite
 --require spec_helper

--- a/lib/dor/was_seed/content_metadata_generator.rb
+++ b/lib/dor/was_seed/content_metadata_generator.rb
@@ -15,6 +15,8 @@ module Dor
         write_file_to_druid_metadata_folder(CONTENT_METADATA, metadata_content)
       end
 
+      private
+
       def generate_xml_doc(image_xml_str = '')
         xml_input = "<?xml version=\"1.0\"?><item><druid>#{@druid_id}</druid>#{image_xml_str}</item>"
         Nokogiri::XML(xml_input)

--- a/lib/dor/was_seed/content_metadata_generator.rb
+++ b/lib/dor/was_seed/content_metadata_generator.rb
@@ -9,17 +9,17 @@ module Dor
       CONTENT_METADATA = 'contentMetadata'
 
       def generate_metadata_output
-        xml_input = generate_xml_doc(create_thumbnail_xml_element("#{DruidTools::Druid.new(@druid_id, workspace).content_dir}/thumbnail.jp2"))
-        metadata_content = transform_xml_using_xslt(xml_input, read_template(CONTENT_METADATA))
+        ng_xml_for_thumbnail = ng_doc(create_thumbnail_xml_element("#{DruidTools::Druid.new(@druid_id, workspace).content_dir}/thumbnail.jp2"))
+        metadata_content = transform_xml_using_xslt(ng_xml_for_thumbnail, read_template(CONTENT_METADATA))
         metadata_content = do_post_transform(metadata_content)
         write_file_to_druid_metadata_folder(CONTENT_METADATA, metadata_content)
       end
 
       private
 
-      def generate_xml_doc(image_xml_str = '')
-        xml_input = "<?xml version=\"1.0\"?><item><druid>#{@druid_id}</druid>#{image_xml_str}</item>"
-        Nokogiri::XML(xml_input)
+      def ng_doc(image_xml_str = '')
+        xml = "<?xml version=\"1.0\"?><item><druid>#{@druid_id}</druid>#{image_xml_str}</item>"
+        Nokogiri::XML(xml)
       end
 
       def create_thumbnail_xml_element(thumbnail_file)

--- a/spec/lib/dor/was_seed/content_metadata_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/content_metadata_generator_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
-  let(:staging_path) { Pathname(File.dirname(__FILE__)).join('../fixtures/') }
   let(:expected_thumbnail_xml_element) { '<image><md5>cecab42610cefd7f8ba80c8505a0f95f</md5><sha1>c78e5e8e8ca02c6fffa9169b0e9e4df908675fdc</sha1><size>228709</size><width>1000</width><height>1215</height></image>' }
   let(:expected_full_xml_element) { Nokogiri::XML("<item><druid>druid:aa111aa1111</druid>#{expected_thumbnail_xml_element}</item>") }
   let(:cm_generator_instance_with_druid) { described_class.new('', 'druid:aa111aa1111') }
@@ -63,17 +62,16 @@ RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
   end
 
   describe '#create_thumbnail_xml_element' do
-    it 'returns valid xml element for a regular image', :image_prerequisite do
-      thumbnail_file_location = "#{staging_path}/thumbnail_files/thumbnail.jp2"
-      actual_xml_element = cm_generator_instance.create_thumbnail_xml_element thumbnail_file_location
-      expect(actual_xml_element).to eq(expected_thumbnail_xml_element)
-      # expected_xml_objet = Nokogiri::XML(expected_thumbnail_xml_element)
-      # actual_xml_object  = Nokogiri::XML(actual_xml_element)
-      # expect(actual_xml_object).to be_equivalent_to(expected_xml_objet)
+    let(:fixture_path) { 'spec/was_seed_preassembly/fixtures' }
+
+    it 'returns valid xml element for a thumbnail image' do
+      thumbnail_file_location = "#{fixture_path}/thumbnail_files/thumbnail.jp2"
+      actual_xml_element = described_class.new('', '').send(:create_thumbnail_xml_element, thumbnail_file_location)
+      expect(actual_xml_element).to be_equivalent_to(expected_thumbnail_xml_element)
     end
 
     it 'returns empty string for non-existing images' do
-      thumbnail_file_location = "#{staging_path}/thumbnail_files/nonthing.jpeg"
+      thumbnail_file_location = "#{fixture_path}/thumbnail_files/not_there.jpeg"
       actual_xml_element = described_class.new('', '').send(:create_thumbnail_xml_element, thumbnail_file_location)
       expect(actual_xml_element).to eq('')
     end
@@ -85,12 +83,12 @@ RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
 
     it 'raises an exception for reading an empty image' do
       # TODO: ? This test case should be fixed with adding an empty image
-      thumbnail_file_location = "#{staging_path}/thumbnail_files/thumbnail_empty.jpeg"
+      thumbnail_file_location = "#{fixture_path}/thumbnail_files/thumbnail_empty.jpeg"
       expect { described_class.new.send(:create_thumbnail_xml_element, thumbnail_file_location) }.to raise_error StandardError
     end
 
     it 'raises an error for reading an invalid image' do
-      thumbnail_file_location = "#{staging_path}/thumbnail_files/thumbnail_text.jpeg"
+      thumbnail_file_location = "#{fixture_path}/thumbnail_files/thumbnail_text.jpeg"
       expect { described_class.new.send(:create_thumbnail_xml_element, thumbnail_file_location) }.to raise_error StandardError
     end
   end

--- a/spec/lib/dor/was_seed/content_metadata_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/content_metadata_generator_service_spec.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
-  before(:all) do
-    @staging_path = Pathname(File.dirname(__FILE__)).join('../fixtures/')
-    @expected_thumbnal_xml_element = '<image><md5>cecab42610cefd7f8ba80c8505a0f95f</md5><sha1>c78e5e8e8ca02c6fffa9169b0e9e4df908675fdc</sha1><size>228709</size><width>1000</width><height>1215</height></image>'
-    @expected_full_xml_element = Nokogiri::XML("<item><druid>druid:aa111aa1111</druid>#{@expected_thumbnal_xml_element}</item>")
-    @expected_empty_xml_element = Nokogiri::XML('<item><druid>druid:aa111aa1111</druid></item>')
-  end
+  let(:staging_path) { Pathname(File.dirname(__FILE__)).join('../fixtures/') }
+  let(:expected_thumbnail_xml_element) { '<image><md5>cecab42610cefd7f8ba80c8505a0f95f</md5><sha1>c78e5e8e8ca02c6fffa9169b0e9e4df908675fdc</sha1><size>228709</size><width>1000</width><height>1215</height></image>' }
+  let(:expected_full_xml_element) { Nokogiri::XML("<item><druid>druid:aa111aa1111</druid>#{expected_thumbnail_xml_element}</item>") }
+  let(:cm_generator_instance_with_druid) { described_class.new('', 'druid:aa111aa1111') }
 
   describe '#generate_metadata_output' do
     let(:druid_id) { 'druid:gh123gh1234' }
@@ -41,62 +39,64 @@ RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
 
       expected_output_file = "#{workspace}/gh/123/gh/1234/gh123gh1234/metadata/contentMetadata.xml"
       actual_content_metadata = File.read(expected_output_file)
-      expect(actual_content_metadata).to eq expected_xml
+      expect(actual_content_metadata).to be_equivalent_to(expected_xml)
     end
   end
 
-  describe '.generate_xml_doc' do
+  describe '#generate_xml_doc' do
+    let(:expected_empty_xml_element) { Nokogiri::XML('<item><druid>druid:aa111aa1111</druid></item>') }
+
     it 'returns a complete xml element for valid druid and an image xml element' do
-      actual_xml_element = cm_generator_instance_with_druid.generate_xml_doc @expected_thumbnal_xml_element
-      expect(actual_xml_element.to_xml).to eq(@expected_full_xml_element.to_xml)
-      # expect(actual_xml_element).to be_equivalent_to(@expected_full_xml_element)
+      actual_xml_element = cm_generator_instance_with_druid.send(:generate_xml_doc, expected_thumbnail_xml_element)
+      expect(actual_xml_element).to be_equivalent_to(expected_full_xml_element)
     end
 
     it 'returns a basic xml element for a valid druid and empty xml element' do
-      actual_xml_element =  cm_generator_instance_with_druid.generate_xml_doc ''
-      expect(actual_xml_element.to_xml).to eq(@expected_empty_xml_element.to_xml)
+      actual_xml_element =  cm_generator_instance_with_druid.send(:generate_xml_doc, '')
+      expect(actual_xml_element).to be_equivalent_to(expected_empty_xml_element)
     end
 
-    it 'returns a basic xml element for a valid druid and empty xml element' do
-      actual_xml_element =  cm_generator_instance_with_druid.generate_xml_doc
-      expect(actual_xml_element.to_xml).to eq(@expected_empty_xml_element.to_xml)
+    it 'returns a basic xml element for a valid druid and missing xml element' do
+      actual_xml_element =  cm_generator_instance_with_druid.send(:generate_xml_doc)
+      expect(actual_xml_element).to be_equivalent_to(expected_empty_xml_element)
     end
   end
 
-  describe '.create_thumbnail_xml_element' do
+  describe '#create_thumbnail_xml_element' do
     it 'returns valid xml element for a regular image', :image_prerequisite do
-      thumbnail_file_location = "#{@staging_path}/thumbnail_files/thumbnail.jp2"
+      thumbnail_file_location = "#{staging_path}/thumbnail_files/thumbnail.jp2"
       actual_xml_element = cm_generator_instance.create_thumbnail_xml_element thumbnail_file_location
-      expect(actual_xml_element).to eq(@expected_thumbnal_xml_element)
-      # expected_xml_objet = Nokogiri::XML(@expected_thumbnal_xml_element)
+      expect(actual_xml_element).to eq(expected_thumbnail_xml_element)
+      # expected_xml_objet = Nokogiri::XML(expected_thumbnail_xml_element)
       # actual_xml_object  = Nokogiri::XML(actual_xml_element)
       # expect(actual_xml_object).to be_equivalent_to(expected_xml_objet)
     end
 
     it 'returns empty string for non-existing images' do
-      thumbnail_file_location = "#{@staging_path}/thumbnail_files/nonthing.jpeg"
-      actual_xml_element = cm_generator_instance.create_thumbnail_xml_element thumbnail_file_location
+      thumbnail_file_location = "#{staging_path}/thumbnail_files/nonthing.jpeg"
+      actual_xml_element = described_class.new('', '').send(:create_thumbnail_xml_element, thumbnail_file_location)
       expect(actual_xml_element).to eq('')
     end
 
-    it 'returns empty string for null location string' do
-      actual_xml_element = cm_generator_instance.create_thumbnail_xml_element nil
+    it 'returns empty string for nil location string' do
+      actual_xml_element = described_class.new('', '').send(:create_thumbnail_xml_element, nil)
       expect(actual_xml_element).to eq('')
     end
 
-    it 'raises an excetion for reading an empty image' do
+    it 'raises an exception for reading an empty image' do
       # TODO: ? This test case should be fixed with adding an empty image
-      thumbnail_file_location = "#{@staging_path}/thumbnail_files/thumbnail_empty.jpeg"
-      expect { create_thumbnail_xml_element thumbnail_file_location }.to raise_error StandardError
+      thumbnail_file_location = "#{staging_path}/thumbnail_files/thumbnail_empty.jpeg"
+      expect { described_class.new.send(:create_thumbnail_xml_element, thumbnail_file_location) }.to raise_error StandardError
     end
 
     it 'raises an error for reading an invalid image' do
-      thumbnail_file_location = "#{@staging_path}/thumbnail_files/thumbnail_text.jpeg"
-      expect { create_thumbnail_xml_element thumbnail_file_location }.to raise_error StandardError
+      thumbnail_file_location = "#{staging_path}/thumbnail_files/thumbnail_text.jpeg"
+      expect { described_class.new.send(:create_thumbnail_xml_element, thumbnail_file_location) }.to raise_error StandardError
     end
   end
 
-  describe '.transform_xml_using_xslt' do
+  # this method is in MetadataGenerator
+  describe '#transform_xml_using_xslt' do
     let(:content_metadata_full) do
       '<contentMetadata type="webarchive-seed" id="druid:aa111aa1111">
  <resource type="image" sequence="1" id="aa111aa1111_1">
@@ -111,16 +111,8 @@ RSpec.describe Dor::WasSeed::ContentMetadataGenerator do
 
     it 'transforms the xml to content metadata data format using XSLT' do
       xslt_template = File.read(Pathname(File.dirname(__FILE__)).join('../../../../template/wasSeedPreassembly/contentMetadata.xslt'))
-      actual_content_metadata = cm_generator_instance.transform_xml_using_xslt @expected_full_xml_element, xslt_template
-      expect(actual_content_metadata).to be_equivalent_to content_metadata_full
+      actual_content_metadata = described_class.new('', '').transform_xml_using_xslt(expected_full_xml_element, xslt_template)
+      expect(actual_content_metadata).to be_equivalent_to(content_metadata_full)
     end
-  end
-
-  def cm_generator_instance
-    Dor::WasSeed::ContentMetadataGenerator.new('', '')
-  end
-
-  def cm_generator_instance_with_druid(druid = 'druid:aa111aa1111')
-    Dor::WasSeed::ContentMetadataGenerator.new('', druid)
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #497

Removes the last :image_prerequisite tag from specs.  

Also refactors content_metadata_generator_service_spec so I could stand to work with it.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


