### PR TITLE
use vips instead of mini_magick for resizing seed images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'assembly-image', '~> 2.0' # was-seed-preassembly thumbnail creation; 2.0.0 uses vips
+gem 'assembly-image', '~> 2.0' # was-seed-preassembly thumbnail creation; 2.0.0 uses libvips
 gem 'druid-tools'
 gem 'dor-services-client', '~> 12.0'
 gem 'dor-workflow-client', '~> 4.0'
@@ -11,15 +11,14 @@ gem 'stanford-mods', '~> 2.6'
 
 gem 'config', '~> 2.0'
 gem 'honeybadger'
-gem 'lockfile'       # file locks needed for mutual exclusion during rollup and index addition processes
-gem 'mini_exiftool'  # was-seed-preassembly thumbnail creation
-gem 'mini_magick'    # was-seed-preassembly thumbnail creation
+gem 'lockfile'       # file locks needed for mutual exclusion during wayback index rollup and addition processes
+gem 'mini_exiftool'  # was-seed-preassembly thumbnail - used to check mimetype and to get height and width
 gem 'pry'            # for bin/console
 gem 'rake'
 gem 'resque'
 gem 'resque-pool'
 gem 'rubyzip'        # warc_extractor_service
-gem 'ruby-vips'      # image processing for thumbnail creation
+gem 'ruby-vips'      # was-seed-preassembly thumbnail creation image processing with libvips
 gem 'slop'           # for bin/run_robot
 gem 'whenever'       # for cron jobs
 gem 'zeitwerk', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_exiftool (2.10.2)
-    mini_magick (4.11.0)
     mini_portile2 (2.8.0)
     minitest (5.16.2)
     mods (2.4.1)
@@ -296,7 +295,6 @@ DEPENDENCIES
   lockfile
   lyber-core (~> 6.0)
   mini_exiftool
-  mini_magick
   pry
   pry-byebug
   rake
@@ -314,4 +312,4 @@ DEPENDENCIES
   zeitwerk (~> 2.1)
 
 BUNDLED WITH
-   2.3.17
+   2.3.16

--- a/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
     let(:thumbnail_jp2_file) { 'spec/was_seed_preassembly/fixtures/workspace/ab/123/cd/4567/ab123cd4567/content/thumbnail.jp2' }
 
     before do
-      FileUtils.rm thumbnail_jp2_file, force: true
+      FileUtils.rm_f thumbnail_jp2_file
       # the following fakes the result of calling .screenshot by putting a file where a result is expected
       FileUtils.cp 'spec/was_seed_preassembly/fixtures/thumbnail_files/ab123cd4567.jpeg', screenshot_jpeg_file
     end
 
     after do
-      FileUtils.rm thumbnail_jp2_file, force: true
+      FileUtils.rm_f thumbnail_jp2_file
       FileUtils.rm_rf 'spec/was_seed_preassembly/fixtures/workspace/ab'
-      FileUtils.rm screenshot_jpeg_file, force: true
+      FileUtils.rm_f screenshot_jpeg_file
     end
 
     it 'generates max 400 px jp2 from jpeg screenshot and pushes to druid_tree content directory', js: true do
@@ -67,51 +67,54 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
   end
 
   describe '.resize_jpeg' do
+    let(:resized_jpeg_file) { 'tmp/resized.jpeg' }
+
     after do
-      FileUtils.rm 'tmp/thum_extra_width.jpeg', force: true
-      FileUtils.rm 'tmp/thum_extra_height.jpeg', force: true
+      FileUtils.rm_f 'tmp/resize_extra_width.jpeg'
+      FileUtils.rm_f 'tmp/resize_extra_height.jpeg'
+      FileUtils.rm_f resized_jpeg_file
     end
 
     it 'resizes the image with extra width to maximum 400 pixel width' do
       original_file = 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_width.jpeg'
-      generated_thumb_file = 'tmp/thum_extra_width.jpeg'
-      FileUtils.cp(original_file, generated_thumb_file)
-      described_class.resize_jpeg(generated_thumb_file)
+      original_file_copy = 'tmp/resize_extra_width.jpeg'
+      FileUtils.cp(original_file, original_file_copy)
+      described_class.resize_jpeg(original_file_copy, resized_jpeg_file)
 
       # access: :sequential is faster to load than random (default), but less good for processing
       original_image = Vips::Image.new_from_file(original_file, access: :sequential)
       expected_thumb_image = Vips::Image.new_from_file('spec/was_seed_preassembly/fixtures/thumbnail_files/thum_extra_width.jpeg', access: :sequential)
-      generated_thumb_image = Vips::Image.new_from_file(generated_thumb_file, access: :sequential)
+      generated_thumb_jpeg = Vips::Image.new_from_file(resized_jpeg_file, access: :sequential)
       # what follows is a poor attempt to indicate this is a true thumbnail for the given image.
-      expect(generated_thumb_image.width).to be < original_image.width
-      expect(generated_thumb_image.height).to be < original_image.height
-      expect(generated_thumb_image.width).to eq 400
-      expect(generated_thumb_image.height).to eq 348
-      expect(generated_thumb_image.width).to eq expected_thumb_image.width
-      expect(generated_thumb_image.height).to eq expected_thumb_image.height
+      expect(generated_thumb_jpeg.width).to be < original_image.width
+      expect(generated_thumb_jpeg.height).to be < original_image.height
+      expect(generated_thumb_jpeg.width).to eq 400
+      expect(generated_thumb_jpeg.height).to eq 348
+      expect(generated_thumb_jpeg.width).to eq expected_thumb_image.width
+      expect(generated_thumb_jpeg.height).to eq expected_thumb_image.height
       # this comparison of the image content itself (by the pixel) courtesy of Tony Calavano
-      expect((expected_thumb_image == generated_thumb_image).min).to be < 255.0
+      expect((expected_thumb_image == generated_thumb_jpeg).min).to be < 255.0
     end
 
     it 'resizes the image with extra height to maximum 400 pixel height' do
       original_file = 'spec/was_seed_preassembly/fixtures/thumbnail_files/image_extra_height.jpeg'
-      generated_thumb_file = 'tmp/thum_extra_height.jpeg'
-      FileUtils.cp(original_file, generated_thumb_file)
-      described_class.resize_jpeg(generated_thumb_file)
+      original_file_copy = 'tmp/resize_extra_height.jpeg'
+      FileUtils.cp(original_file, original_file_copy)
+      described_class.resize_jpeg(original_file_copy, resized_jpeg_file)
 
       # access: :sequential is faster to load than random (default), but less good for processing
       original_image = Vips::Image.new_from_file(original_file, access: :sequential)
       expected_thumb_image = Vips::Image.new_from_file('spec/was_seed_preassembly/fixtures/thumbnail_files/thum_extra_height.jpeg', access: :sequential)
-      generated_thumb_image = Vips::Image.new_from_file(generated_thumb_file, access: :sequential)
+      generated_thumb_jpeg = Vips::Image.new_from_file(resized_jpeg_file, access: :sequential)
       # what follows is a poor attempt to indicate this is a true thumbnail for the given image.
-      expect(generated_thumb_image.width).to be < original_image.width
-      expect(generated_thumb_image.height).to be < original_image.height
-      expect(generated_thumb_image.width).to eq 227
-      expect(generated_thumb_image.height).to eq 400
-      expect(generated_thumb_image.width).to eq expected_thumb_image.width
-      expect(generated_thumb_image.height).to eq expected_thumb_image.height
+      expect(generated_thumb_jpeg.width).to be < original_image.width
+      expect(generated_thumb_jpeg.height).to be < original_image.height
+      expect(generated_thumb_jpeg.width).to eq 227
+      expect(generated_thumb_jpeg.height).to eq 400
+      expect(generated_thumb_jpeg.width).to eq expected_thumb_image.width
+      expect(generated_thumb_jpeg.height).to eq expected_thumb_image.height
       # this comparison of the image content itself (by the pixel) courtesy of Tony Calavano
-      expect((expected_thumb_image == generated_thumb_image).min).to be < 255.0
+      expect((expected_thumb_image == generated_thumb_jpeg).min).to be < 255.0
     end
   end
 


### PR DESCRIPTION
~~Marking hold so Andrew or Peter Chan can vet this doesn't cause any performance problems.~~

## Why was this change made? 🤔

assembly-image 2.0 has moved to vips;  let's leverage vips and have fewer other dependencies

Part of #458

## How was this change tested? 🤨

test code.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


