### PR TITLE
seed thumb generator looks for blank, not nil, in cdxj_indexer response body

### DIFF
--- a/lib/dor/was_seed/thumbnail_generator_service.rb
+++ b/lib/dor/was_seed/thumbnail_generator_service.rb
@@ -48,7 +48,7 @@ module Dor
       def self.indexed?(seed_uri)
         cdx_index_url = "#{Settings.cdxj_indexer.url}#{seed_uri}"
         response = Net::HTTP.get_response(URI(cdx_index_url))
-        return unless response.body.nil?
+        return unless response.body.blank? # body is empty string when it's missing.
 
         raise StandardError, "#{seed_uri} not found in cdxj index."
       end

--- a/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
@@ -10,11 +10,14 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
     let(:uri) { 'http://www.slac.stanford.edu' }
     let(:screenshot_jpeg_file) { 'tmp/ab123cd4567.jpeg' }
     let(:thumbnail_jp2_file) { 'spec/was_seed_preassembly/fixtures/workspace/ab/123/cd/4567/ab123cd4567/content/thumbnail.jp2' }
+    let(:cdxj_indexer_response) { Net::HTTPSuccess.new(1.0, '200', 'OK') }
 
     before do
       FileUtils.rm_f thumbnail_jp2_file
       # the following fakes the result of calling .screenshot by putting a file where a result is expected
       FileUtils.cp 'spec/was_seed_preassembly/fixtures/thumbnail_files/ab123cd4567.jpeg', screenshot_jpeg_file
+      allow(Net::HTTP).to receive(:get_response).and_return(cdxj_indexer_response)
+      allow(cdxj_indexer_response).to receive(:body).and_return('not empty signifying I am in the index')
     end
 
     after do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #515 

It turns out when the cdxj indexer does NOT have a url, it returns an HTTP response with status 200 and a body of an empty string, rather than a nil body.

```
3.0.3 (main):0 Pry > url = 'https://was-pywb-qa.stanford.edu/was/cdx?url=https://honeybadger.io'
=> true
3.0.3 (main):0 Pry > response = Net::HTTP.get_response(URI(url))
=> #<Net::HTTPOK 200 OK readbody=true>
3.0.3 (main):0 Pry > response.body
=> ""
```

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


