### PR TITLE
Don't wait too long

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -13,7 +13,7 @@ async function run() {
         await page.setViewport({ width: 1200, height: 800 });
         await page.goto(process.argv[2], {
           timeout: 30000, 
-          waitUntil: 'networkidle0'
+          waitUntil: 'networkidle2'
         });
         await page.screenshot({ path: process.argv[3], format: 'jpeg' });
     } catch (err) {


### PR DESCRIPTION
## Why was this change made? 🤔

Using `networkidle0` waits until there is no remaining network activity before taking the screenshot. This might be too conservative and we can wait for no more than 2 with `networkidle2`, which seems to be the practice for pages on the web.

Closes #518

## How was this change tested? 🤨

This test works with `networkidle2` but throws a timeout error with`networkidle0`:

```
node scripts/screenshot.js https://swap.stanford.edu/was/20171025171815/https://www.stanforddaily.com/2017/10/19/letter-to-the-editor-boards-response-to-su-prison-divest/ test.jpg
```

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


