### PR TITLE
Remove fedora setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,3 @@
-fedora:
-  url: ~
-
 ssl:
   cert_file: ~
   key_file: ~


### PR DESCRIPTION
## Why was this change made? 🤔
No more fedora. Will follow up with update to shared configs. 

## How was this change tested? 🤨
Unit tests

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


