### PR TITLE
Set puppeteer temp directory.

### DIFF
--- a/lib/dor/was_seed/thumbnail_generator_service.rb
+++ b/lib/dor/was_seed/thumbnail_generator_service.rb
@@ -28,7 +28,10 @@ module Dor
       end
 
       def self.screenshot(wayback_uri, screenshot_jpeg)
-        _stdout_str, stderr_str, _status = Open3.capture3("node scripts/screenshot.js #{wayback_uri} #{screenshot_jpeg} #{Settings.chrome_path}")
+        stderr_str = nil
+        Dir.mktmpdir do |tmp_dir|
+          _stdout_str, stderr_str, _status = Open3.capture3({ 'PUPPETEER_TMP_DIR' => tmp_dir }, "node scripts/screenshot.js #{wayback_uri} #{screenshot_jpeg} #{Settings.chrome_path}")
+        end
         raise stderr_str unless File.exist?(screenshot_jpeg)
       end
 


### PR DESCRIPTION
closes #526

## Why was this change made? 🤔
Puppeteer files were filling up temp space.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

I'm not sure how to test this.
