### PR TITLE
Escape URL in CDX check.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,7 +24,7 @@ cdxj_indexer:
   working_directory: /web-archiving-stacks/data/indexes/cdxj_working
   backup_directory: /web-archiving-stacks/data/indexes/cdxj_backup
   main_cdxj_file: /web-archiving-stacks/data/indexes/cdxj/level0.cdxj
-  url: ~
+  url: http://localhost/was/cdx?url=
 
 was_seed:
   workspace_path: '/dor/workspace/'  #the root for the storage for DRUID tree that will be the input to AssemblyWF

--- a/lib/dor/was_seed/thumbnail_generator_service.rb
+++ b/lib/dor/was_seed/thumbnail_generator_service.rb
@@ -54,7 +54,7 @@ module Dor
       # param seed_uri [String] the seed URI to verify if it exists in the index
       # raises [StandardError] if seed_uri is not found in the cdxj index
       def self.indexed?(seed_uri)
-        cdx_index_url = "#{Settings.cdxj_indexer.url}#{seed_uri}"
+        cdx_index_url = "#{Settings.cdxj_indexer.url}#{CGI.escape(seed_uri)}"
         response = Net::HTTP.get_response(URI(cdx_index_url))
         return unless response.body.blank? # body is empty string when it's missing.
 

--- a/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
+++ b/spec/lib/dor/was_seed/thumbnail_generator_service_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe Dor::WasSeed::ThumbnailGeneratorService do
         allow(Net::HTTP).to receive(:get_response).and_return(response)
         allow(response).to receive(:body).and_return(response_body)
         expect(described_class.indexed?(uri)).to be_nil
+        expect(Net::HTTP).to have_received(:get_response).with(URI('http://localhost/was/cdx?url=http%3A%2F%2Fwww.slac.stanford.edu'))
       end
     end
 


### PR DESCRIPTION
closes #529

## Why was this change made? 🤔
So that CDX check works correctly.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Unit
