### PR TITLE
Adds scheduled rake task for cleaning up backup directories.

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,6 +7,11 @@ every 1.day, roles: [:rollup] do
   rake 'cdxj:index:rollup:level1'
 end
 
+every 1.week, roles: [:rollup] do
+  rake 'cdxj:index:cleanup:indexes'
+  rake 'cdxj:index:cleanup:empty_directories'
+end
+
 every 1.month, roles: [:rollup] do
   rake 'cdxj:index:rollup:level2'
 end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -48,5 +48,18 @@ namespace :cdxj do
         cdxj_rollup.rollup
       end
     end
+
+    namespace :cleanup do
+      desc 'Cleans cdxj backups empty directories'
+      task empty_directories: :environment do
+        # Setting mindepth to 1 prevents the command from wiping out the root dir if empty
+        `find #{Settings.cdxj_indexer.backup_directory} -mindepth 1 -not -path "*/\.*" -type d -empty -delete`
+      end
+
+      desc 'Clean cdxj backups'
+      task indexes: :environment do
+        `find #{Settings.cdxj_indexer.backup_directory} -mindepth 2 -type f -ctime +7 -delete`
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #535

## Why was this change made? 🤔
Good file hygiene.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Rake tasks tested on QA.
