### PR TITLE
Quoting URI arg passed to screenshot.js

### DIFF
--- a/lib/dor/was_seed/thumbnail_generator_service.rb
+++ b/lib/dor/was_seed/thumbnail_generator_service.rb
@@ -35,7 +35,7 @@ module Dor
       def self.screenshot(wayback_uri, screenshot_jpeg)
         stderr_str = nil
         Dir.mktmpdir do |tmp_dir|
-          _stdout_str, stderr_str, _status = Open3.capture3({ 'PUPPETEER_TMP_DIR' => tmp_dir }, "node scripts/screenshot.js #{wayback_uri} #{screenshot_jpeg} #{Settings.chrome_path}")
+          _stdout_str, stderr_str, _status = Open3.capture3({ 'PUPPETEER_TMP_DIR' => tmp_dir }, "node scripts/screenshot.js '#{wayback_uri}' #{screenshot_jpeg} #{Settings.chrome_path}")
         end
         raise stderr_str unless File.exist?(screenshot_jpeg)
       end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #539. Errors with thumbnail generation with seed URLs.

## How was this change tested? 🤨
Unit and on QA

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


