### PR TITLE
Manage dependencies via poetry

### DIFF
--- a/.autoupdate/preupdate
+++ b/.autoupdate/preupdate
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script is called by our weekly dependency update job in Jenkins, before updating Ruby and other deps
+
+# Without these ENV changes, python gets confused and tries to use latin1
+# encodings which breaks the poetry update below
+export LANG=en_US.UTF-8
+export LC_COLLATE=C.UTF-8
+
+pip3 install --upgrade --requirement requirements.txt > was_robot_suite.txt &&
+    ~/.local/bin/poetry update -n --no-ansi >> was_robot_suite.txt &&
+    git add poetry.lock &&
+    git commit -m "Update Python dependencies"
+
+retVal=$?
+
+if [ $retVal -ne 0 ]; then
+    echo "ERROR UPDATING PYTHON (was_robot_suite)"
+    cat was_robot_suite.txt
+fi
+
+cd ..

--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ to start all robots defined in `config/environments/robots_ENV.yml`.
 
 ## Deployment
 
-Various dependencies, including `cdxj-indexer` which is installed by puppet via `pip3`, can be found in `config/settings.yml` and [shared_configs](https://github.com/sul-dlss/shared_configs) (was-robotsxxx branches)
+Various dependencies, including `cdxj-indexer` which is installed via `pip3` and `poetry`, can be found in `config/settings.yml` and [shared_configs](https://github.com/sul-dlss/shared_configs) (was-robotsxxx branches). To install `cdxj-indexer`:
+
+```shell
+$ poetry install
+```
+
+And then to run it:
+
+```shell
+$ poetry run cdxj-indexer --args --follow --here
+```
 
 ## Prerequisites
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,7 +20,7 @@ was_crawl_dissemination:
   stacks_collections_path: "/web-archiving-stacks/data/collections/"
 
 cdxj_indexer:
-  bin: /opt/app/was/.local/bin/cdxj-indexer
+  bin: /opt/app/was/.local/bin/poetry run cdxj-indexer
   working_directory: /web-archiving-stacks/data/indexes/cdxj_working
   backup_directory: /web-archiving-stacks/data/indexes/cdxj_backup
   main_cdxj_file: /web-archiving-stacks/data/indexes/cdxj/level0.cdxj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "was_robot_suite"
+version = "0.1.0"
+description = "Web Archiving Robots"
+authors = ["Michael J. Giarlo <mjgiarlo@stanford.edu>"]
+license = "Apache 2.0"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+cdxj-indexer = "^1.4.5"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cdxj-indexer
+poetry

--- a/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Robots::DorRepo::WasCrawlDissemination::CdxjGenerator do
 
     let(:druid) { 'druid:dd116zh0343' }
     let(:sys_cmd) do
-      '/opt/app/was/.local/bin/cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc ' \
+      '/opt/app/was/.local/bin/poetry run cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc ' \
         '--output tmp/druid:dd116zh0343/number1.cdxj --dir-root /web-archiving-stacks/data/collections/ --post-append 2>> log/cdx_indexer.log'
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #538

This lets us manage dependencies more like we do in Rubyland and JSland. Also hook into JenkinsCI to update Python dependencies.


## How was this change tested? 🤨

CI, not yet tested in a deployed env
