### PR TITLE
Change source of thumbnail capture URI

### DIFF
--- a/lib/robots/dor_repo/base.rb
+++ b/lib/robots/dor_repo/base.rb
@@ -13,6 +13,17 @@ module Robots
         Dor::Services::Client.object(druid).find.label
       end
 
+      def original_site_uri(druid)
+        cocina_object = Dor::Services::Client.object(druid).find
+        uri_note = cocina_object.description.note.find { |note| note.displayLabel == 'Original site' }
+        # if no original site note, use title since this is likely the first time generating
+        uri = uri_note&.value || cocina_object.description.title.first.value
+        return uri unless uri.start_with?('Web Archive Seed for')
+
+        # use label if the title and note are not usable for the uri
+        cocina_object.label
+      end
+
       def workspace_path
         Settings.was_seed.workspace_path
       end

--- a/lib/robots/dor_repo/base.rb
+++ b/lib/robots/dor_repo/base.rb
@@ -13,17 +13,6 @@ module Robots
         Dor::Services::Client.object(druid).find.label
       end
 
-      def original_site_uri(druid)
-        cocina_object = Dor::Services::Client.object(druid).find
-        uri_note = cocina_object.description.note.find { |note| note.displayLabel == 'Original site' }
-        # if no original site note, use title since this is likely the first time generating
-        uri = uri_note&.value || cocina_object.description.title.first.value
-        return uri unless uri.start_with?('Web Archive Seed for')
-
-        # use label if the title and note are not usable for the uri
-        cocina_object.label
-      end
-
       def workspace_path
         Settings.was_seed.workspace_path
       end

--- a/lib/robots/dor_repo/was_seed_preassembly/thumbnail_generator.rb
+++ b/lib/robots/dor_repo/was_seed_preassembly/thumbnail_generator.rb
@@ -10,7 +10,7 @@ module Robots
 
         def perform(druid)
           LyberCore::Log.info "Creating ThumbnailGenerator with parameters #{druid}"
-          Dor::WasSeed::ThumbnailGeneratorService.capture_thumbnail(druid, workspace_path, seed_uri(druid))
+          Dor::WasSeed::ThumbnailGeneratorService.capture_thumbnail(druid, workspace_path, original_site_uri(druid))
         end
       end
     end

--- a/lib/robots/dor_repo/was_seed_preassembly/thumbnail_generator.rb
+++ b/lib/robots/dor_repo/was_seed_preassembly/thumbnail_generator.rb
@@ -24,10 +24,9 @@ module Robots
           # it did not make it to accessioning and reflects the initial registration value
           uri = uri_note&.value || cocina_object.description.title.first.value
           # in the case that the title field reflects changes made in accessioning, do not use it
-          return uri unless uri.start_with?('Web Archive Seed for')
+          raise StandardError, 'No thumbnail URL available in the description.note or description.title' if uri.start_with?('Web Archive Seed for')
 
-          # use label if the title and note are not usable for the URI
-          cocina_object.label
+          uri
         end
       end
     end

--- a/lib/robots/dor_repo/was_seed_preassembly/thumbnail_generator.rb
+++ b/lib/robots/dor_repo/was_seed_preassembly/thumbnail_generator.rb
@@ -12,6 +12,23 @@ module Robots
           LyberCore::Log.info "Creating ThumbnailGenerator with parameters #{druid}"
           Dor::WasSeed::ThumbnailGeneratorService.capture_thumbnail(druid, workspace_path, original_site_uri(druid))
         end
+
+        private
+
+        def original_site_uri(druid)
+          cocina_object = Dor::Services::Client.object(druid).find
+          # if the seed already made it through accessioning, there should be a descriptive note with the URI
+          # this is also the field that can be updated to correct a seed URL
+          uri_note = cocina_object.description.note.find { |note| note.displayLabel == 'Original site' }
+          # if there is no note, then the seed is either being newly registered or
+          # it did not make it to accessioning and reflects the initial registration value
+          uri = uri_note&.value || cocina_object.description.title.first.value
+          # in the case that the title field reflects changes made in accessioning, do not use it
+          return uri unless uri.start_with?('Web Archive Seed for')
+
+          # use label if the title and note are not usable for the URI
+          cocina_object.label
+        end
       end
     end
   end

--- a/spec/robots/dor_repo/was_seed_preassembly/thumbnail_generator_spec.rb
+++ b/spec/robots/dor_repo/was_seed_preassembly/thumbnail_generator_spec.rb
@@ -56,22 +56,21 @@ RSpec.describe Robots::DorRepo::WasSeedPreassembly::ThumbnailGenerator do
       end
     end
 
-    context 'when re-generating the thumbnail and title has been updated but there is no note' do
+    context 'when re-generating the thumbnail and title has been updated and there is no note' do
       let(:cocina_model) do
-        build(:dro, id: druid, label: url).new(description: {
-                                                 purl: 'https://purl.stanford.edu/bc123df4567',
-                                                 title: [
-                                                   {
-                                                     value: 'Web Archive Seed for http://abc123.edu'
-                                                   }
-                                                 ]
-                                               })
+        build(:dro, id: druid).new(description: {
+                                     purl: 'https://purl.stanford.edu/bc123df4567',
+                                     title: [
+                                       {
+                                         value: 'Web Archive Seed for http://abc123.edu'
+                                       }
+                                     ]
+                                   })
       end
 
-      it 'invokes thumbnail generator service and finds the URI in the label' do
-        instance.perform(druid)
-        expect(Dor::Services::Client).to have_received(:object).with(druid)
-        expect(Dor::WasSeed::ThumbnailGeneratorService).to have_received(:capture_thumbnail).with(druid, '/dor/workspace/', url)
+      it 'raises an error' do
+        # instance.perform(druid)
+        expect { instance.perform(druid) }.to raise_error(StandardError)
       end
     end
   end

--- a/spec/robots/dor_repo/was_seed_preassembly/thumbnail_generator_spec.rb
+++ b/spec/robots/dor_repo/was_seed_preassembly/thumbnail_generator_spec.rb
@@ -2,20 +2,77 @@
 
 RSpec.describe Robots::DorRepo::WasSeedPreassembly::ThumbnailGenerator do
   describe 'perform' do
-    let(:druid) { 'druid:ab123cd4567' }
+    let(:druid) { 'druid:bc123df4567' }
     let(:instance) { described_class.new }
     let(:url) { 'http://abc123.edu' }
-    let(:model) { instance_double(Cocina::Models::DRO, label: url) }
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: model) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
 
     before do
-      allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(Dor::WasSeed::ThumbnailGeneratorService).to receive(:capture_thumbnail)
     end
 
-    it 'invokes thumbnail generator service' do
-      instance.perform(druid)
-      expect(Dor::WasSeed::ThumbnailGeneratorService).to have_received(:capture_thumbnail).with(druid, '/dor/workspace/', url)
+    context 'when generating a thumbnail when there is no note yet' do
+      let(:cocina_model) do
+        build(:dro, id: druid).new(description: {
+                                     purl: 'https://purl.stanford.edu/bc123df4567',
+                                     title: [
+                                       {
+                                         value: 'http://abc123.edu'
+                                       }
+                                     ]
+                                   })
+      end
+
+      it 'invokes thumbnail generator service and finds the URI in the title' do
+        instance.perform(druid)
+        expect(Dor::Services::Client).to have_received(:object).with(druid)
+        expect(Dor::WasSeed::ThumbnailGeneratorService).to have_received(:capture_thumbnail).with(druid, '/dor/workspace/', url)
+      end
+    end
+
+    context 'when re-generating a thumbnail' do
+      let(:cocina_model) do
+        build(:dro, id: druid).new(description: {
+                                     purl: 'https://purl.stanford.edu/bc123df4567',
+                                     note: [
+                                       {
+                                         value: url,
+                                         displayLabel: 'Original site'
+                                       }
+                                     ],
+                                     title: [
+                                       {
+                                         value: 'Web Archive Seed for http://abc123.edu'
+                                       }
+                                     ]
+                                   })
+      end
+
+      it 'invokes thumbnail generator service and finds the URI in the note' do
+        instance.perform(druid)
+        expect(Dor::Services::Client).to have_received(:object).with(druid)
+        expect(Dor::WasSeed::ThumbnailGeneratorService).to have_received(:capture_thumbnail).with(druid, '/dor/workspace/', url)
+      end
+    end
+
+    context 'when re-generating the thumbnail and title has been updated but there is no note' do
+      let(:cocina_model) do
+        build(:dro, id: druid, label: url).new(description: {
+                                                 purl: 'https://purl.stanford.edu/bc123df4567',
+                                                 title: [
+                                                   {
+                                                     value: 'Web Archive Seed for http://abc123.edu'
+                                                   }
+                                                 ]
+                                               })
+      end
+
+      it 'invokes thumbnail generator service and finds the URI in the label' do
+        instance.perform(druid)
+        expect(Dor::Services::Client).to have_received(:object).with(druid)
+        expect(Dor::WasSeed::ThumbnailGeneratorService).to have_received(:capture_thumbnail).with(druid, '/dor/workspace/', url)
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #544.

## How was this change tested? 🤨
Unit, added unit tests, and tested on stage

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


