### PR TITLE
Setting tempdir for cdxj indexing

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,6 +25,7 @@ cdxj_indexer:
   backup_directory: /web-archiving-stacks/data/indexes/cdxj_backup
   main_cdxj_file: /web-archiving-stacks/data/indexes/cdxj/level0.cdxj
   url: http://localhost/was/cdx?url=
+  tmpdir: /tmp
 
 was_seed:
   workspace_path: '/dor/workspace/'  #the root for the storage for DRUID tree that will be the input to AssemblyWF

--- a/lib/dor/was_crawl/cdxj_generator_service.rb
+++ b/lib/dor/was_crawl/cdxj_generator_service.rb
@@ -33,7 +33,8 @@ module Dor
       def generate_cdx_for_one_warc(warc_file_name)
         cdx_file_path  = cdx_file_name(warc_file_name)
         warc_file_path = "#{druid_base_directory}/#{warc_file_name}"
-        cmd_string = "#{Settings.cdxj_indexer.bin} #{warc_file_path} --output #{cdx_file_path} --dir-root #{Settings.was_crawl_dissemination.stacks_collections_path} --post-append 2>> log/cdx_indexer.log"
+        cmd_string = "TMPDIR=#{Settings.cdxj_indexer.tmpdir} " \
+                     "#{Settings.cdxj_indexer.bin} #{warc_file_path} --output #{cdx_file_path} --dir-root #{Settings.was_crawl_dissemination.stacks_collections_path} --post-append 2>> log/cdx_indexer.log"
         Dor::WasCrawl::Dissemination::Utilities.run_sys_cmd(cmd_string, 'extracting CDXJ')
       end
     end

--- a/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Robots::DorRepo::WasCrawlDissemination::CdxjGenerator do
 
     let(:druid) { 'druid:dd116zh0343' }
     let(:sys_cmd) do
-      '/opt/app/was/.local/bin/poetry run cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc ' \
+      'TMPDIR=/tmp /opt/app/was/.local/bin/poetry ' \
+        'run cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc ' \
         '--output tmp/druid:dd116zh0343/number1.cdxj --dir-root /web-archiving-stacks/data/collections/ --post-append 2>> log/cdx_indexer.log'
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #545. Can set TMPDIR to a larger partition on prod.  Will also require adding a tmpdir setting to was-robots1-prod settings in shared_configs. 

## How was this change tested? 🤨
Unit tests and QA. 

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


