### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -16,7 +16,6 @@ require 'capistrano/deploy'
 #   https://github.com/capistrano/bundler
 #   https://github.com/capistrano/rails
 #
-require 'capistrano/rvm'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
 require 'capistrano/bundler'

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ end
 
 group :deployment do
   gem 'capistrano-bundler'
-  gem 'capistrano-rvm', require: false
   gem 'capistrano-yarn' # for generating was-seed-preassembly thumbnail with chrome (PR #242)
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,9 +36,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     capistrano-yarn (2.0.2)
       capistrano (~> 3.0)
@@ -283,7 +280,6 @@ DEPENDENCIES
   assembly-image (~> 2.0)
   awesome_print
   capistrano-bundler
-  capistrano-rvm
   capistrano-yarn
   config (~> 2.0)
   dlss-capistrano


### PR DESCRIPTION
## Why was this change made? 🤔

This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.



## How was this change tested? 🤨

Deployed to stage
