### PR TITLE
Remove errant resque require.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 
 require 'bundler'
 require 'rake'
-require 'resque/pool/tasks'
 
 # Import external rake tasks
 Dir.glob('lib/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
closes #592

## Why was this change made? 🤔
So that indexing update cron jobs work correctly.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Prod.

```
$ cd /opt/app/was/was_robot_suite/releases/20230306175817 && ROBOT_ENVIRONMENT=production bundle exec rake "cdxj:index:rollup:level1"
** [Honeybadger] Initializing Honeybadger Error Tracker for Ruby. Ship it! version=5.1.0 framework=ruby level=1 pid=2062440
Merging via LC_ALL=C sort --merge --unique --output=/web-archiving-stacks/data/indexes/cdxj/level1.cdxj.new /web-archiving-stacks/data/indexes/cdxj/level0.cdxj /web-archiving-stacks/data/indexes/cdxj/level1.cdxj
```
