### PR TITLE
Set TMPDIR when sorting

### DIFF
--- a/lib/dor/was_crawl/cdxj_merge_service.rb
+++ b/lib/dor/was_crawl/cdxj_merge_service.rb
@@ -80,7 +80,10 @@ module Dor
       def sort_env_vars
         # Ensure that the index is sorted by byte values
         # See https://specs.webrecorder.net/cdxj/0.1.0/#sorting
-        'LC_ALL=C'
+        #
+        # Also ensure that the configured temporary directory is used
+        # so that /tmp doesn't fill up
+        "LC_ALL=C TMPDIR=#{Settings.cdxj_indexer.tmpdir}"
       end
     end
   end

--- a/lib/dor/was_crawl/cdxj_rollup_service.rb
+++ b/lib/dor/was_crawl/cdxj_rollup_service.rb
@@ -46,7 +46,10 @@ module Dor
       def sort_env_vars
         # Ensure that the index is sorted by byte values
         # See https://specs.webrecorder.net/cdxj/0.1.0/#sorting
-        'LC_ALL=C'
+        #
+        # Also ensure that the configured temporary directory is used
+        # so that /tmp doesn't fill up
+        "LC_ALL=C TMPDIR=#{Settings.cdxj_indexer.tmpdir}"
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

When sorting CDXJ files `/tmp` will be used as temp space for sorting when the files don't fit in memory. This is usually ok, but when the CDXJ files being sorted are larger than what fits in `/tmp` an out of space error will be encoutered. Setting `TMPDIR` to the space used by CDXJ file generation uses should help solve this problem.

Closes #594

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


