### PR TITLE
pin pdfjs-dist to 3.4.120 to work with node 1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "dependencies": {
     "puppeteer": "^14.4.1",
     "ejs": "^3.1.8",
-    "pdfjs-dist": "latest"
+    "pdfjs-dist": "3.4.120"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,7 +519,7 @@ path2d-polyfill@^2.0.1:
   resolved "https://registry.yarnpkg.com/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz#24c554a738f42700d6961992bf5f1049672f2391"
   integrity sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==
 
-pdfjs-dist@^3.4.120:
+pdfjs-dist@3.4.120:
   version "3.4.120"
   resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-3.4.120.tgz#6f4222117157498f179c95dc4569fad6336a8fdd"
   integrity sha512-B1hw9ilLG4m/jNeFA0C2A0PZydjxslP8ylU+I4XM7Bzh/xWETo9EiBV848lh0O0hLut7T6lK1V7cpAXv5BhxWw==


### PR DESCRIPTION
## Why was this change made? 🤔

dep updates were undeployable due to this error:

```
error pdfjs-dist@3.5.141: The engine "node" is incompatible with this module. Expected version ">=16". Got "14.19.3"
error Found incompatible module.
yarn stderr: Nothing written
```

version 3.5 was recently released:

![image](https://user-images.githubusercontent.com/96775/230981699-e3b4132e-5350-4238-96fb-7feee5cf8106.png)



Upgrading the version of node on the servers seems like a whole 'nother project.  


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


