### PR TITLE
Allow PDF rendering for any URL

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -33,7 +33,7 @@ async function run() {
   } catch (err) {
     // Puppeteer cannot screenshot PDFs in headless mode by itself, so get some help from EJS and PDF.js
     // HT: https://stackoverflow.com/a/70437748
-    if (err.message.match('net::ERR_ABORTED') && uri.match(/pdf/i)) {
+    if (err.message.match('net::ERR_ABORTED')) {
       try {
         await page.addScriptTag({path: './node_modules/pdfjs-dist/build/pdf.min.js'});
         await page.addScriptTag({path: './node_modules/pdfjs-dist/build/pdf.worker.min.js'});


### PR DESCRIPTION
## Why was this change made? 🤔

We have some fallback code to try a PDF render of a URL when headless chrome fails to screenshot. Unfortunately that depends on the URL having a `pdf` in the URL, which isn't really required for a PDF document on the web.

This commit relaxes the constraint on the URL name, which will allow a screenshot to be generated from a PDF at a URL like https://wayback.archive-it.org/11377/20181120231857/http://sanjoseca.gov/DocumentCenter/View/79490/

Fixes #632

## How was this change tested? 🤨

Unit
