### PR TITLE
New kakadu URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ workflows:
             - run:
                 name: Install Kakadu
                 command: |
-                  curl http://kakadusoftware.com/wp-content/uploads/KDU805_Demo_Apps_for_Linux-x86-64_200602.zip --output kakadu.zip
+                  curl https://kakadusoftware.com/wp-content/uploads/KDU841_Demo_Apps_for_Linux-x86-64_231117.zip --output kakadu.zip
                   unzip kakadu.zip
-                  mv KDU805_Demo_Apps_for_Linux-x86-64_200602 kakadu
+                  mv KDU841_Demo_Apps_for_Linux-x86-64_231117 kakadu
                   sudo cp kakadu/*.so /usr/lib
                   sudo cp kakadu/* /usr/bin


### PR DESCRIPTION
## Why was this change made? 🤔

The old demo kakadu URL was a 404, which caused our builds to fail. I registered for a new demo URL and added it to the CircleCI config.

Fixes #648

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


