### PR TITLE
Add pipx path to PATH environment variable in CI hook

### DIFF
--- a/.autoupdate/preupdate
+++ b/.autoupdate/preupdate
@@ -7,6 +7,9 @@
 export LANG=en_US.UTF-8
 export LC_COLLATE=C.UTF-8
 
+# Needed to successfully run `pipx`
+export PATH="$HOME/.local/bin:$PATH"
+
 pip3 install --user pipx > was_robot_suite.txt &&
   pipx install poetry --force >> was_robot_suite.txt &&
   ~/.local/bin/poetry update -n --no-ansi >> was_robot_suite.txt &&


### PR DESCRIPTION
# Why was this change made?

Fix weekly update CI.

# How was this change tested?

Created a custom access-update-scripts branch pointed at this branch and ran it, producing: https://github.com/sul-dlss/was_robot_suite/pull/677
