### PR TITLE
Use modern RSpec defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ config/environments/dev.rb
 spec/was_seed_preassembly/fixtures/workspace
 node_modules/
 spec/lib/dor/was_crawl/fixtures/stacks/data/indices/path_working/*
+
+# RSpec state file
+spec/examples.txt

--- a/spec/robots/dor_repo/was_crawl_preassembly/build_was_crawl_druid_tree_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_preassembly/build_was_crawl_druid_tree_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Robots::DorRepo::WasCrawlPreassembly::BuildWasCrawlDruidTree do
+RSpec.describe Robots::DorRepo::WasCrawlPreassembly::BuildWasCrawlDruidTree do
   describe '.initialize' do
     it 'initializes the robot with valid parameters' do
       robot = described_class.new

--- a/spec/robots/dor_repo/was_crawl_preassembly/end_was_crawl_preassembly_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_preassembly/end_was_crawl_preassembly_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly do
+RSpec.describe Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly do
   describe '.initialize' do
     it 'initializes the robot with valid parameters' do
       robot = described_class.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,53 @@ include LyberCore::Rspec # rubocop:disable Style/MixinUsage
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
+  config.disable_monkey_patching!
+
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
@@ -35,17 +82,17 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  # config.profile_examples = 10
+  config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  # config.order = :random
+  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
-  # Kernel.srand config.seed
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
## Why was this change made? 🤔
So that we have a state file, which enables `rspec --only-failures`


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


