### PR TITLE
Remove code for changing lanes

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,6 @@ dor_services:
 was_crawl:
   source_path: '/was_unaccessioned_data/jobs/' # the root for the storage for the input directory
   staging_path: '/dor/workspace/' # the root for the storage for DRUID tree that will be the input to AssemblyWF
-  dedicated_lane: 'default'
 
 was_crawl_dissemination:
   main_cdxj_file: '/web-archiving-stacks/data/indexes/cdxj/level0.cdxj'

--- a/lib/robots/dor_repo/was_crawl_preassembly/end_was_crawl_preassembly.rb
+++ b/lib/robots/dor_repo/was_crawl_preassembly/end_was_crawl_preassembly.rb
@@ -10,14 +10,7 @@ module Robots
 
         def perform_work
           current_version = object_client.version.current
-          workflow_service.create_workflow_by_name(druid, 'accessionWF', lane_id: was_lane_id,
-                                                                         version: current_version)
-        end
-
-        private
-
-        def was_lane_id
-          Settings.was_crawl.dedicated_lane
+          workflow_service.create_workflow_by_name(druid, 'accessionWF', version: current_version)
         end
       end
     end

--- a/spec/robots/dor_repo/was_crawl_preassembly/end_was_crawl_preassembly_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_preassembly/end_was_crawl_preassembly_spec.rb
@@ -21,21 +21,12 @@ RSpec.describe Robots::DorRepo::WasCrawlPreassembly::EndWasCrawlPreassembly do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     end
 
-    it 'starts the accessionWF on default lane' do
+    it 'starts the accessionWF' do
       allow(workflow_client).to receive(:create_workflow_by_name)
       robot = described_class.new
       test_perform(robot, druid)
       expect(workflow_client).to have_received(:create_workflow_by_name)
-        .with(druid, workflow_name, lane_id: 'default', version: '1')
-    end
-
-    it 'starts the accessionWF on a non-default lane' do
-      Settings.was_crawl.dedicated_lane = 'NotDefault'
-      allow(workflow_client).to receive(:create_workflow_by_name)
-      robot = described_class.new
-      test_perform(robot, druid)
-      expect(workflow_client).to have_received(:create_workflow_by_name)
-        .with(druid, workflow_name, lane_id: 'NotDefault', version: '1')
+        .with(druid, workflow_name, version: '1')
     end
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔


We always use the default. This is less code to maintain. This also removes a flaky spec
## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


