### PR TITLE
Remove unnecessary capistrano setting

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,7 +20,7 @@ set :deploy_to, "/opt/app/was/#{fetch(:application)}"
 # set :log_level, :debug
 
 # Default value for :pty is false
-set :pty, true
+# set :pty, true
 
 # Default value for :linked_files is []
 set :linked_files, %w(config/honeybadger.yml)


### PR DESCRIPTION


## Why was this change made? 🤔
The default works fine.  Most of our projects use it.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


