### PR TITLE
Adds filesize for thumbnails.

### DIFF
--- a/lib/dor/was_seed/structural_builder.rb
+++ b/lib/dor/was_seed/structural_builder.rb
@@ -62,6 +62,7 @@ module Dor
             { type: 'md5', digest: assembly_objectfile.md5 }
           ],
           presentation: { height:, width: },
+          size: assembly_objectfile.filesize,
           hasMimeType: 'image/jp2',
           access: { view: object_access.view, download: object_access.download }
         )

--- a/spec/lib/dor/was_seed/structural_builder_spec.rb
+++ b/spec/lib/dor/was_seed/structural_builder_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Dor::WasSeed::StructuralBuilder do
                                                   externalIdentifier: 'https://cocina.sul.stanford.edu/file/1',
                                                   label: 'thumbnail.jp2',
                                                   filename: 'thumbnail.jp2',
+                                                  size: 228_709,
                                                   version: 1,
                                                   presentation: {
                                                     height: 1215,


### PR DESCRIPTION
closes #700

## Why was this change made? 🤔
Production bug; embed viewer requires file size.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Unit
