### PR TITLE
Change HB alerts to raise.

### DIFF
--- a/lib/robots/dor_repo/was_crawl_preassembly/start.rb
+++ b/lib/robots/dor_repo/was_crawl_preassembly/start.rb
@@ -10,7 +10,7 @@ module Robots
         end
 
         def perform_work
-          Honeybadger.notify('[WARNING] WAS crawl pre-assembly has been started with an object that is not open') unless object_client.version.status.open?
+          raise 'WAS crawl pre-assembly has been started with an object that is not open' unless object_client.version.status.open?
         end
       end
     end

--- a/lib/robots/dor_repo/was_seed_preassembly/start.rb
+++ b/lib/robots/dor_repo/was_seed_preassembly/start.rb
@@ -10,7 +10,7 @@ module Robots
         end
 
         def perform_work
-          Honeybadger.notify('[WARNING] WAS seed pre-assembly has been started with an object that is not open') unless object_client.version.status.open?
+          raise 'WAS seed pre-assembly has been started with an object that is not open' unless object_client.version.status.open?
         end
       end
     end

--- a/spec/robots/dor_repo/was_crawl_preassembly/start_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_preassembly/start_spec.rb
@@ -20,19 +20,15 @@ RSpec.describe Robots::DorRepo::WasCrawlPreassembly::Start do
   describe '#perform' do
     subject(:perform) { test_perform(robot, druid) }
 
-    before { allow(Honeybadger).to receive(:notify) }
-
-    it 'does not notify Honeybadger' do
-      perform
-      expect(Honeybadger).not_to have_received(:notify)
+    it 'does not raise an error' do
+      expect { perform }.not_to raise_error
     end
 
     context 'when object is not open' do
       let(:version_open) { false }
 
-      it 'notifies Honeybadger' do
-        perform
-        expect(Honeybadger).to have_received(:notify).once.with('[WARNING] WAS crawl pre-assembly has been started with an object that is not open')
+      it 'raises' do
+        expect { perform }.to raise_error('WAS crawl pre-assembly has been started with an object that is not open')
       end
     end
   end

--- a/spec/robots/dor_repo/was_seed_preassembly/start_spec.rb
+++ b/spec/robots/dor_repo/was_seed_preassembly/start_spec.rb
@@ -20,19 +20,15 @@ RSpec.describe Robots::DorRepo::WasSeedPreassembly::Start do
   describe '#perform' do
     subject(:perform) { test_perform(robot, druid) }
 
-    before { allow(Honeybadger).to receive(:notify) }
-
-    it 'does not notify Honeybadger' do
-      perform
-      expect(Honeybadger).not_to have_received(:notify)
+    it 'does not raise an error' do
+      expect { perform }.not_to raise_error
     end
 
     context 'when object is not open' do
       let(:version_open) { false }
 
-      it 'notifies Honeybadger' do
-        perform
-        expect(Honeybadger).to have_received(:notify).once.with('[WARNING] WAS seed pre-assembly has been started with an object that is not open')
+      it 'raises' do
+        expect { perform }.to raise_error('WAS seed pre-assembly has been started with an object that is not open')
       end
     end
   end


### PR DESCRIPTION
closes #702

## Why was this change made? 🤔
If this happens, it is a problem, not an inconvenience.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Unit
