### PR TITLE
Screenshot refinements

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,7 +20,7 @@ cdxj_indexer:
   working_directory: /web-archiving-stacks/data/indexes/cdxj_working
   backup_directory: /web-archiving-stacks/data/indexes/cdxj_backup
   main_cdxj_file: /web-archiving-stacks/data/indexes/cdxj/level0.cdxj
-  url: http://localhost/was/cdx?url=
+  url: https://swap.stanford.edu/was/cdx
   tmpdir: /tmp
 
 was_seed:

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -1,10 +1,9 @@
 const ejs = require('ejs');
-const path = require('path');
 const puppeteer = require('puppeteer');
 
 /*
 / Usage:
-/  node scripts/screenshot.js url output chrome-path
+/  node scripts/screenshot.js url output [chrome-path]
 /
 */
 async function run() {
@@ -26,9 +25,12 @@ async function run() {
   try {
     await page.setViewport({ width: 1200, height: 800 });
     await page.goto(uri, {
-      timeout: 30000,
+      timeout: 60000,
       waitUntil: 'networkidle2'
     });
+    // wait a little bit longer for the page to potentially finish rendering
+    // see: https://github.com/sul-dlss/was_robot_suite/issues/570
+    await sleep(10);
     await page.screenshot({ path: process.argv[3], format: 'jpeg' });
   } catch (err) {
     // Puppeteer cannot screenshot PDFs in headless mode by itself, so get some help from EJS and PDF.js
@@ -52,6 +54,10 @@ async function run() {
   } finally {
     await browser.close()
   }
+}
+
+function sleep(seconds) { 
+  return new Promise(r => setTimeout(r, seconds * 1000));
 }
 
 run();


### PR DESCRIPTION
This PR should be merged along with these small shared-config changes:

* https://github.com/sul-dlss/shared_configs/pull/2226
* https://github.com/sul-dlss/shared_configs/pull/2225

## Why was this change made? 🤔

In order to prevent incorrect screenshots we:

1. Wait ten seconds after the network is idle for the page to
   potentially finish rendering, before taking the screenshot.
2. Determine the last 200 OK snapshot in the archive instead of getting the first one
   which could be a redirect to another page that isn't desired for the screenshot.

Fixes #570

## How was this change tested? 🤨

Integration tests in stage.



