### PR TITLE
Handle multi-wacz-package extraction

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,11 +63,6 @@ Metrics/PerceivedComplexity:
     - 'lib/dor/was_seed/file_set.rb'
 
 # Offense count: 1
-RSpec/BeforeAfterAll:
-  Exclude:
-    - 'spec/lib/dor/was_crawl/warc_extractor_service_spec.rb'
-
-# Offense count: 1
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,6 +63,11 @@ Metrics/PerceivedComplexity:
     - 'lib/dor/was_seed/file_set.rb'
 
 # Offense count: 1
+RSpec/BeforeAfterAll:
+  Exclude:
+    - 'spec/lib/dor/was_crawl/warc_extractor_service_spec.rb'
+
+# Offense count: 1
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:

--- a/lib/dor/was_crawl/warc_extractor_service.rb
+++ b/lib/dor/was_crawl/warc_extractor_service.rb
@@ -16,14 +16,9 @@ module Dor
       end
 
       def extract
-        Zip::File.open(wacz_filepath) do |wacz_file|
-          wacz_file.glob('archive/*.warc.gz').each do |warc_entry|
-            filename = warc_entry.name.delete_prefix('archive/')
-            # Prefixing with WACZ filename to make unique.
-            warc_entry.extract(File.join(base_path, "#{wacz_basename}-#{filename}"))
-          end
-        end
-        File.delete(wacz_filepath)
+        extract_multi_wacz_package if data_package_profile == 'multi-wacz-package'
+
+        extract_data_package
       end
 
       private
@@ -36,6 +31,45 @@ module Dor
 
       def wacz_basename
         @wacz_basename ||= File.basename(wacz_filename, '.wacz')
+      end
+
+      def wacz_data_package
+        Zip::File.open(wacz_filepath) do |wacz_file|
+          @wacz_data_package ||= JSON.parse(wacz_file.glob('datapackage.json').first.get_input_stream.read)
+        end
+      end
+
+      def data_package_profile
+        @data_package_profile ||= wacz_data_package['profile']
+      end
+
+      def data_package_resources
+        @data_package_resources ||= wacz_data_package['resources']
+      end
+
+      def extract_data_package
+        Zip::File.open(wacz_filepath) do |wacz_file|
+          wacz_file.glob('archive/*.warc.gz').each do |warc_entry|
+            filename = warc_entry.name.delete_prefix('archive/')
+            # Prefixing with WACZ filename to make unique.
+            warc_entry.extract(File.join(base_path, "#{wacz_basename}-#{filename}"))
+          end
+        end
+        File.delete(wacz_filepath)
+      end
+
+      def extract_multi_wacz_package
+        multi_wacz_filepath = wacz_filepath
+        Zip::File.open(multi_wacz_filepath) do |wacz_file|
+          data_package_resources.each do |resource|
+            wacz_file.glob(resource['path']).each do |warc_entry|
+              @wacz_filename = "#{wacz_basename}-#{Pathname.new(warc_entry.name).basename}"
+              # Prefixing with WACZ filename to make unique.
+              warc_entry.extract(File.join(base_path, wacz_filename))
+            end
+          end
+        end
+        File.delete(multi_wacz_filepath)
       end
     end
   end

--- a/lib/dor/was_crawl/warc_extractor_service.rb
+++ b/lib/dor/was_crawl/warc_extractor_service.rb
@@ -52,6 +52,9 @@ module Dor
         Zip::File.open(filepath) do |wacz_file|
           wacz_file.glob('archive/*.warc.gz').each do |warc_entry|
             filename = warc_entry.name.delete_prefix('archive/')
+            # Skip screenshots and text files as we do not use or preserve them.
+            next if filename.downcase.match?(/screenshot|text/)
+
             # Prefixing with WACZ filename to make unique.
             warc_entry.extract(File.join(base_path, "#{wacz_basename}-#{filename}"))
           end

--- a/spec/lib/dor/was_crawl/warc_extractor_service_spec.rb
+++ b/spec/lib/dor/was_crawl/warc_extractor_service_spec.rb
@@ -30,9 +30,8 @@ RSpec.describe Dor::WasCrawl::WarcExtractorService do
       it 'extracts the WARC files' do
         described_class.extract('tmp/ee111ee1111', 'Multi-WACZ-Test.wacz')
         expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-20240823165728702-0.warc.gz')).to be true
-        # TODO: Filter out screenshot and text files, they will still be available in the wacz when preserved.
-        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-screenshots-20240823165731628.warc.gz')).to be true
-        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-text-20240823165731772.warc.gz')).to be true
+        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-screenshots-20240823165731628.warc.gz')).to be false
+        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-text-20240823165731772.warc.gz')).to be false
         expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test.wacz')).to be false
       end
     end

--- a/spec/lib/dor/was_crawl/warc_extractor_service_spec.rb
+++ b/spec/lib/dor/was_crawl/warc_extractor_service_spec.rb
@@ -2,18 +2,32 @@
 
 RSpec.describe Dor::WasCrawl::WarcExtractorService do
   describe '#extract' do
-    before do
+    before :all do
       FileUtils.cp_r 'spec/lib/dor/was_crawl/fixtures/workspace/dd111dd1111', 'tmp/'
     end
 
-    after do
+    after :all do
       FileUtils.rm_rf 'tmp/dd111dd1111'
     end
 
-    it 'extracts the WARC files' do
-      described_class.extract('tmp/dd111dd1111', 'WACZ-Test.wacz')
-      expect(File.exist?('tmp/dd111dd1111/WACZ-Test-data.warc.gz')).to be true
-      expect(File.exist?('tmp/dd111dd1111/WACZ-Test.wacz')).to be false
+    context 'when the data package profile is multi-wacz-package' do
+      it 'extracts the WARC files' do
+        described_class.extract('tmp/dd111dd1111', 'manual-20240813150220-f5365fda-037.wacz')
+        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-20240813150255048-0.warc.gz')).to be true
+        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-20240813150259570-1.warc.gz')).to be true
+        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-20240813150455271-1.warc.gz')).to be true
+        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-screenshots-20240813150258623.warc.gz')).to be true
+        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-text-20240813150258797.warc.gz')).to be true
+        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-20240813154245913-f5365fda-037-0.wacz')).to be false
+      end
+    end
+
+    context 'when the data package profile is data-package' do
+      it 'extracts the WARC files' do
+        described_class.extract('tmp/dd111dd1111', 'WACZ-Test.wacz')
+        expect(File.exist?('tmp/dd111dd1111/WACZ-Test-data.warc.gz')).to be true
+        expect(File.exist?('tmp/dd111dd1111/WACZ-Test.wacz')).to be false
+      end
     end
   end
 end

--- a/spec/lib/dor/was_crawl/warc_extractor_service_spec.rb
+++ b/spec/lib/dor/was_crawl/warc_extractor_service_spec.rb
@@ -2,31 +2,38 @@
 
 RSpec.describe Dor::WasCrawl::WarcExtractorService do
   describe '#extract' do
-    before :all do
-      FileUtils.cp_r 'spec/lib/dor/was_crawl/fixtures/workspace/dd111dd1111', 'tmp/'
-    end
-
-    after :all do
-      FileUtils.rm_rf 'tmp/dd111dd1111'
-    end
-
-    context 'when the data package profile is multi-wacz-package' do
-      it 'extracts the WARC files' do
-        described_class.extract('tmp/dd111dd1111', 'manual-20240813150220-f5365fda-037.wacz')
-        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-20240813150255048-0.warc.gz')).to be true
-        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-20240813150259570-1.warc.gz')).to be true
-        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-20240813150455271-1.warc.gz')).to be true
-        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-screenshots-20240813150258623.warc.gz')).to be true
-        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-my-organization-californiahistoricalsociety-org-manual-20240813150220-f5365fda-037-text-20240813150258797.warc.gz')).to be true
-        expect(File.exist?('tmp/dd111dd1111/manual-20240813150220-f5365fda-037-20240813154245913-f5365fda-037-0.wacz')).to be false
-      end
-    end
-
     context 'when the data package profile is data-package' do
+      before do
+        FileUtils.cp_r 'spec/lib/dor/was_crawl/fixtures/workspace/dd111dd1111', 'tmp/'
+      end
+
+      after do
+        FileUtils.rm_rf 'tmp/dd111dd1111'
+      end
+
       it 'extracts the WARC files' do
         described_class.extract('tmp/dd111dd1111', 'WACZ-Test.wacz')
         expect(File.exist?('tmp/dd111dd1111/WACZ-Test-data.warc.gz')).to be true
         expect(File.exist?('tmp/dd111dd1111/WACZ-Test.wacz')).to be false
+      end
+    end
+
+    context 'when the data package profile is multi-wacz-package' do
+      before do
+        FileUtils.cp_r 'spec/lib/dor/was_crawl/fixtures/workspace/ee111ee1111', 'tmp/'
+      end
+
+      after do
+        FileUtils.rm_rf 'tmp/ee111ee1111'
+      end
+
+      it 'extracts the WARC files' do
+        described_class.extract('tmp/ee111ee1111', 'Multi-WACZ-Test.wacz')
+        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-20240823165728702-0.warc.gz')).to be true
+        # TODO: Filter out screenshot and text files, they will still be available in the wacz when preserved.
+        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-screenshots-20240823165731628.warc.gz')).to be true
+        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test-stanford-library-website-fixture-wacz-manual-20240823165704-eb63421b-c8a-text-20240823165731772.warc.gz')).to be true
+        expect(File.exist?('tmp/ee111ee1111/Multi-WACZ-Test.wacz')).to be false
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #724 

This uses the `multi-wacz-package` json to extract the included wacz file the uses the expected `data-package` format.

```
{
  "profile": "multi-wacz-package",
  "resources": [
    {
      "name": "d3144a11-36d5-49f6-8de0-bc67a100a6dc/20240813154245913-f5365fda-037-0.wacz",
      "path": "d3144a11-36d5-49f6-8de0-bc67a100a6dc/20240813154245913-f5365fda-037-0.wacz",
      "hash": "42e68793218a5f198d489d259ee8276bb26bfb296240dbd0099fd6c9b0743951",
      "size": 3426701790,
      "crawlId": "manual-20240813150220-f5365fda-037",
      "numReplicas": 0,
      "expireAt": "2024-08-25T20:36:29"
    }
  ]
}
```

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


