### PR TITLE
Set package-mode to false in poetry config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Web Archiving Robots"
 authors = ["Michael J. Giarlo <mjgiarlo@stanford.edu>"]
 license = "Apache 2.0"
 
+# we are just using poetry to install dependencies
+package-mode = false
+
 [tool.poetry.dependencies]
 python = "^3.8"
 cdxj-indexer = "^1.4.5"


### PR DESCRIPTION
I found that `poetry install` was returning this locally:

```
$ poetry install
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: was_robot_suite (0.1.0)
Warning: The current project could not be installed: No file/folder found for package was-robot-suite
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
```

Patching this change in got me past the error. We do this already in was-pywb. I assume it's appropriate here? cc: @lwrubel @edsu

