### PR TITLE
Automatically upgrade pipx and poetry

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -59,8 +59,10 @@ namespace :poetry do
       within current_path do
         # Make sure python executables are on the PATH
         with(path: '$HOME/.local/bin:$PATH') do
-          execute :pip3, :install, '--user', 'pipx'
+          execute :pip3, :install, '--user', '--upgrade', 'pipx'
           execute :pipx, :install, 'poetry', '--force'
+          # ensure latest poetry -- pipx install doesn't have an --upgrade flag
+          execute :pipx, :uprade, 'poetry'
           execute :poetry, :install
         end
       end


### PR DESCRIPTION
## Why was this change made? 🤔

We ran into an issue during deployment where Poetry wasn't at the latest version, and so we couldn't use the `package-mode` option in our `pyproject.toml`.

This change will ensure we are running the latest versions of pipx and poetry when doing a deployment. I guess the downside is that it could get updated when doing the deployment, and lead to a failure that isn't easy to observe in our dev environments?

## How was this change tested? 🤨

Ran `bundle exec stage deploy` and saw that the deploy succeeded.
