### PR TITLE
Allow WARC filenames to contain spaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0220)
+    mime-types-data (3.2025.0304)
     mini_exiftool (2.14.0)
       ostruct (>= 0.6.0)
       pstore (>= 0.1.3)
@@ -216,7 +216,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.1.10)
+    rack (3.1.11)
     rackup (0.2.3)
       rack (>= 3.0.0.beta1)
       webrick
@@ -224,7 +224,7 @@ GEM
     rake (13.2.1)
     rdoc (6.12.0)
       psych (>= 4.0.0)
-    redis-client (0.23.2)
+    redis-client (0.24.0)
       connection_pool
     regexp_parser (2.10.0)
     reline (0.6.0)
@@ -242,7 +242,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    rubocop (1.73.1)
+    rubocop (1.73.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -257,8 +257,9 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.26.1)
-      rubocop (~> 1.61)
+    rubocop-factory_bot (2.27.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     rubocop-rspec (3.5.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)

--- a/lib/dor/was_crawl/cdxj_generator_service.rb
+++ b/lib/dor/was_crawl/cdxj_generator_service.rb
@@ -34,7 +34,10 @@ module Dor
         cdx_file_path  = cdx_file_name(warc_file_name)
         warc_file_path = "#{druid_base_directory}/#{warc_file_name}"
         cmd_string = "TMPDIR=#{Settings.cdxj_indexer.tmpdir} " \
-                     "#{Settings.cdxj_indexer.bin} #{warc_file_path} --output #{cdx_file_path} --dir-root #{Settings.was_crawl_dissemination.stacks_collections_path} --post-append 2>> log/cdx_indexer.log"
+                     "#{Settings.cdxj_indexer.bin} '#{warc_file_path}' " \
+                     "--output '#{cdx_file_path}' " \
+                     "--dir-root #{Settings.was_crawl_dissemination.stacks_collections_path} " \
+                     '--post-append 2>> log/cdx_indexer.log'
         Dor::WasCrawl::Dissemination::Utilities.run_sys_cmd(cmd_string, 'extracting CDXJ')
       end
     end

--- a/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
+++ b/spec/robots/dor_repo/was_crawl_dissemination/cdxj_generator_spec.rb
@@ -8,9 +8,16 @@ RSpec.describe Robots::DorRepo::WasCrawlDissemination::CdxjGenerator do
 
     let(:druid) { 'druid:dd116zh0343' }
     let(:sys_cmd) do
-      'TMPDIR=/tmp /opt/app/was/.local/bin/poetry ' \
-        'run cdxj-indexer /web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc ' \
-        '--output tmp/druid:dd116zh0343/number1.cdxj --dir-root /web-archiving-stacks/data/collections/ --post-append 2>> log/cdx_indexer.log'
+      [
+        'TMPDIR=/tmp',
+        '/opt/app/was/.local/bin/poetry',
+        "run cdxj-indexer '/web-archiving-stacks/data/collections/xx123xx1234/dd/116/zh/0343/number1.warc'",
+        "--output 'tmp/druid:dd116zh0343/number1.cdxj'",
+        '--dir-root /web-archiving-stacks/data/collections/',
+        '--post-append',
+        '2>>',
+        'log/cdx_indexer.log'
+      ].join(' ')
     end
 
     before do


### PR DESCRIPTION
## Why was this change made? 🤔

When indexing we should quote the WARC filename and the output CDXJ filename so that they don't disrupt the cdxj-indexer system command.

I tested the subsequent sort command works when given a list of CDXJ paths, some of which contain spaces, and it continues to work:

https://github.com/sul-dlss/was_robot_suite/blob/3dccbdd901d2581a90665c78e03731f2e47f3368/lib/dor/was_crawl/cdxj_merge_service.rb#L60

Fixes #765

## How was this change tested? 🤨

CI and the `web_archive_accessioning_spec.rb` integration test.



