### PR TITLE
Allow for empty profile

### DIFF
--- a/lib/dor/was_crawl/warc_extractor_service.rb
+++ b/lib/dor/was_crawl/warc_extractor_service.rb
@@ -18,8 +18,11 @@ module Dor
       def extract
         # TODO: Raise a HB exception if no WARCs are extracted. This would have
         # caught this situation.
-        extract_multi_wacz_package if data_package_profile == 'multi-wacz-package'
-        extract_data_package(wacz_filepath) if data_package_profile == 'data-package'
+        if data_package_profile == 'multi-wacz-package'
+          extract_multi_wacz_package
+        else
+          extract_data_package(wacz_filepath)
+        end
       end
 
       private


### PR DESCRIPTION
## Why was this change made? 🤔

It looks like browsertrix and browsertrix-crawler have started writing
WACZ files with a datapackage.json that lacks a profile. In these cases
we should just assume it's normal wacz. browsertrix does still seem to
be writing multi-wacz's with a profile.

Fixes #783

## How was this change tested? 🤨

Unit tests and doing a one-time-registration for a WACZ in stage.
