### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,3 +1,2 @@
 server 'was-robots1-prod.stanford.edu', user: 'was', roles: %w{web app db monitor rollup worker}
 
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,3 +1,2 @@
 server 'was-robots1-qa.stanford.edu', user: 'was', roles: %w{web app db rollup worker}
 
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,3 +1,2 @@
 server 'was-robots1-stage.stanford.edu', user: 'was', roles: %w{web app db rollup worker}
 
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.