### PR TITLE
Upgrade lybercore and switch to DSC for workflow operations.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,7 @@ source 'https://rubygems.org'
 # stanford dlss gems
 gem 'assembly-image', '~> 2.0' # was-seed-preassembly thumbnail creation; 2.0.0 uses libvips
 gem 'dor-services-client'
-gem 'dor-workflow-client', '~> 7.0'
-gem 'lyber-core', '~> 7.1'
+gem 'lyber-core', '~> 8.0'
 
 gem 'config'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,13 +101,6 @@ GEM
       faraday-retry
       nokogiri
       zeitwerk (~> 2.1)
-    dor-workflow-client (7.8.0)
-      activesupport (>= 7.0.0)
-      deprecation (>= 0.99.0)
-      faraday (~> 2.0)
-      faraday-retry (~> 2.0)
-      nokogiri (~> 1.6)
-      zeitwerk (~> 2.1)
     drb (2.2.3)
     druid-tools (3.0.0)
     dry-core (1.1.0)
@@ -166,11 +159,10 @@ GEM
     lint_roller (1.1.0)
     lockfile (2.1.3)
     logger (1.7.0)
-    lyber-core (7.7.0)
+    lyber-core (8.0.1)
       activesupport
       config
       dor-services-client
-      dor-workflow-client (>= 7.6)
       druid-tools
       honeybadger
       sidekiq (~> 7.0)
@@ -332,10 +324,9 @@ DEPENDENCIES
   debug
   dlss-capistrano
   dor-services-client
-  dor-workflow-client (~> 7.0)
   honeybadger
   lockfile
-  lyber-core (~> 7.1)
+  lyber-core (~> 8.0)
   mini_exiftool
   pry
   rake

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,11 +29,6 @@ was_seed:
   wayback_uri: 'https://swap.stanford.edu'
 
 chrome_path: /usr/bin/google-chrome
-workflow:
-  url: https://example.com/workflow/
-  logfile: 'log/workflow_service.log'
-  shift_age: 'weekly'
-  timeout: 60
 
 redis:
   url: ~

--- a/lib/robots/dor_repo/was_dissemination/start_special_dissemination.rb
+++ b/lib/robots/dor_repo/was_dissemination/start_special_dissemination.rb
@@ -14,7 +14,7 @@ module Robots
           # Theres nothing to do if this is a seed file
           return LyberCore::ReturnState.new(status: :skipped, note: "Nothing to do for #{cocina_object.type}") unless cocina_object.type == Cocina::Models::ObjectType.webarchive_binary
 
-          workflow_service.create_workflow_by_name(druid, 'wasCrawlDisseminationWF', version: cocina_object.version)
+          object_client.workflow('wasCrawlDisseminationWF').create(version: cocina_object.version)
         end
       end
     end


### PR DESCRIPTION
closes #797

## Why was this change made? 🤔
Deprecate workflow service


## How was this change tested? 🤨
Unit, stage

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


